### PR TITLE
Patch to allow using joins in related search

### DIFF
--- a/lib/acts_as_taggable_on/acts_as_taggable_on/related.rb
+++ b/lib/acts_as_taggable_on/acts_as_taggable_on/related.rb
@@ -45,7 +45,7 @@ module ActsAsTaggableOn::Taggable
         group_columns = ActsAsTaggableOn::Tag.using_postgresql? ? grouped_column_names_for(klass) : "#{klass.table_name}.#{klass.primary_key}"
         
         klass.scoped({ :select     => "#{klass.table_name}.*, COUNT(#{ActsAsTaggableOn::Tag.table_name}.id) AS count",
-                       :from       => "#{klass.table_name}, #{ActsAsTaggableOn::Tag.table_name}, #{ActsAsTaggableOn::Tagging.table_name}",
+                       :from       => "(#{klass.table_name}, #{ActsAsTaggableOn::Tag.table_name}, #{ActsAsTaggableOn::Tagging.table_name})",
                        :conditions => ["#{exclude_self} #{klass.table_name}.id = #{ActsAsTaggableOn::Tagging.table_name}.taggable_id AND #{ActsAsTaggableOn::Tagging.table_name}.taggable_type = '#{klass.to_s}' AND #{ActsAsTaggableOn::Tagging.table_name}.tag_id = #{ActsAsTaggableOn::Tag.table_name}.id AND #{ActsAsTaggableOn::Tag.table_name}.name IN (?) AND #{ActsAsTaggableOn::Tagging.table_name}.context = ?", tags_to_find, result_context],
                        :group      => group_columns,
                        :order      => "count DESC" }.update(options))
@@ -59,7 +59,7 @@ module ActsAsTaggableOn::Taggable
 group_columns = ActsAsTaggableOn::Tag.using_postgresql? ? grouped_column_names_for(klass) : "#{klass.table_name}.#{klass.primary_key}"
 
         klass.scoped({ :select     => "#{klass.table_name}.*, COUNT(#{ActsAsTaggableOn::Tag.table_name}.id) AS count",
-                       :from       => "#{klass.table_name}, #{ActsAsTaggableOn::Tag.table_name}, #{ActsAsTaggableOn::Tagging.table_name}",
+                       :from       => "(#{klass.table_name}, #{ActsAsTaggableOn::Tag.table_name}, #{ActsAsTaggableOn::Tagging.table_name})",
                        :conditions => ["#{exclude_self} #{klass.table_name}.id = #{ActsAsTaggableOn::Tagging.table_name}.taggable_id AND #{ActsAsTaggableOn::Tagging.table_name}.taggable_type = '#{klass.to_s}' AND #{ActsAsTaggableOn::Tagging.table_name}.tag_id = #{ActsAsTaggableOn::Tag.table_name}.id AND #{ActsAsTaggableOn::Tag.table_name}.name IN (?)", tags_to_find],
                        :group      => group_columns,
                        :order      => "count DESC" }.update(options))


### PR DESCRIPTION
Hello,
when passing :joins option to related_tags_for, the resulting sql looks like "SELECT ... FROM mytable1, tags, taggings LEFT JOIN mytable2 ON mytable1.t2_id = mytable2.id ...". And server gives an error because it tries to join only 'taggings' with 'mytable2', not what was intended. I tried this patch and it works ok for me.
