### PR TITLE
Cleanup of 'method redefined' warnings

### DIFF
--- a/lib/acts_as_taggable_on/acts_as_taggable_on/related.rb
+++ b/lib/acts_as_taggable_on/acts_as_taggable_on/related.rb
@@ -18,7 +18,11 @@ module ActsAsTaggableOn::Taggable
             def find_related_#{tag_type}_for(klass, options = {})
               related_tags_for('#{tag_type}', klass, options)
             end
-
+          )
+        end
+        
+        unless tag_types.empty?
+          class_eval %(
             def find_matching_contexts(search_context, result_context, options = {})
               matching_contexts_for(search_context.to_s, result_context.to_s, self.class, options)
             end


### PR DESCRIPTION
This commit prevents find_matching_contexts and find_matching_contexts_for from being defined multiple times when you specify tagging on multiple contexts, as in:

```
acts_as_taggable_on :a, :b, :c
```
## Background (in case you're interested)

I test with the warning flag on but filter warnings that come from gems because, at least as far as rails is concerned, I am in the minority to do so.  The filter checks the warning to see if it has a gem path in it, like:

```
/Users/Simon/.bundle/ruby/1.8/gems/acts-as-taggable-on-2.0.6/lib.... warning: instance variable @tag_list not initialized
```

The class_eval in related.rb evades this filter because there is no line/file info attached (that's how I could see this warning in the first place):

```
(eval):11: warning: method redefined; discarding old find_matching_contexts
```

If you wanted to attach line/file info you could do it like this:

```
tag_types.map(&:to_s).each do |tag_type|
  line = __LINE__
  class_eval %(
    ....
  ), __FILE__, line + 1
```

I use that pattern so that any warnings/errors in the eval will have meaningful debugging info.  You can see the difference if you raise an error somewhere in class_eval.  It's not super important in this case but I have found this pattern useful and though you might as well.
