### PR TITLE
Performance tunning on tagged_with(:any => true)

### DIFF
--- a/lib/acts_as_taggable_on/acts_as_taggable_on/core.rb
+++ b/lib/acts_as_taggable_on/acts_as_taggable_on/core.rb
@@ -89,7 +89,7 @@ module ActsAsTaggableOn::Taggable
                           "   ON #{ActsAsTaggableOn::Tagging.table_name}.tag_id = #{ActsAsTaggableOn::Tag.table_name}.id"
 
           tagging_join << "  AND " + sanitize_sql(["#{ActsAsTaggableOn::Tagging.table_name}.context = ?", context.to_s]) if context
-          select_clause = "DISTINCT #{table_name}.*" unless context
+          select_clause = "DISTINCT #{table_name}.*" unless context and tag_types.one?
 
           joins << tagging_join
 


### PR DESCRIPTION
I made a little change in method tagged_with when supplied :any => true, to use JOIN instead of IN to compose the fetch query, in order to improve its performance. With a few tests in my real application, a query that took ~ 6.5 seconds was reduced to ~ 0.2 seconds, after change. Please consider to merge the changes with main repository so I can use it on my application. Any questions or suggestions, please contact me. Tks
