### PR TITLE
escaping % and _ in tag string

### DIFF
--- a/lib/acts_as_taggable_on/tag.rb
+++ b/lib/acts_as_taggable_on/tag.rb
@@ -20,19 +20,19 @@ module ActsAsTaggableOn
     end
 
     def self.named(name)
-      where(["name #{like_operator} ?", name])
+      where(["name #{like_operator} ?", escape_like(name)])
     end
   
     def self.named_any(list)
-      where(list.map { |tag| sanitize_sql(["name #{like_operator} ?", tag.to_s]) }.join(" OR "))
+      where(list.map { |tag| sanitize_sql(["name #{like_operator} ?", escape_like(tag)]) }.join(" OR "))
     end
   
     def self.named_like(name)
-      where(["name #{like_operator} ?", "%#{name}%"])
+      where(["name #{like_operator} ?", "%#{escape_like(name)}%"])
     end
 
     def self.named_like_any(list)
-      where(list.map { |tag| sanitize_sql(["name #{like_operator} ?", "%#{tag.to_s}%"]) }.join(" OR "))
+      where(list.map { |tag| sanitize_sql(["name #{like_operator} ?", "%#{escape_like(tag)}%"]) }.join(" OR "))
     end
 
     ### CLASS METHODS:
@@ -72,6 +72,11 @@ module ActsAsTaggableOn
 
     class << self
       private
+        # escape _ and % characters in strings, since these are wildcards in SQL.
+        def escape_like(str)
+          str.to_s.gsub("_", "\\\_").gsub("%", "\\\%")
+        end
+        
         def like_operator
           using_postgresql? ? 'ILIKE' : 'LIKE'
         end


### PR DESCRIPTION
Since these are wildcards in ANSI SQL they must be escaped.

Could not get the specs working for either Rails 2.3.10 or 3.0.3. Rails 2.3.10 suite complained about Bundler (which should not be needed, and did not work when I installed it) and Rails 3.0.3 suite would not even run (on Ruby 1.9.2).

So it's not BDD but the patch does work; I have it in production on www.radio1.nl.
