### PR TITLE
Avoid migration clash

### DIFF
--- a/lib/generators/acts_as_taggable_on/migration/migration_generator.rb
+++ b/lib/generators/acts_as_taggable_on/migration/migration_generator.rb
@@ -19,7 +19,7 @@ module ActsAsTaggableOn
     end
 
     def self.next_migration_number(path)
-      Time.now.utc.strftime("%Y%m%d%H%M%S")
+      ActiveRecord::Generators::Base.next_migration_number(path)
     end
 
     def create_migration_file


### PR DESCRIPTION
Current migration number generation method clashes when called after another migration in the same script.

ActiveRecord::Generators::Base.next_migration_number avoids it.
