### PR TITLE
tagged_with('') shouldn't return a hash

### DIFF
--- a/lib/acts_as_taggable_on/acts_as_taggable_on/core.rb
+++ b/lib/acts_as_taggable_on/acts_as_taggable_on/core.rb
@@ -67,8 +67,9 @@ module ActsAsTaggableOn::Taggable
       #   User.tagged_with("awesome", "cool", :match_all => true) # Users that are tagged with just awesome and cool
       def tagged_with(tags, options = {})
         tag_list = ActsAsTaggableOn::TagList.from(tags)
+        empty_result = scoped(:conditions => "1 = 0")
 
-        return {} if tag_list.empty?
+        return empty_result if tag_list.empty?
 
         joins = []
         conditions = []
@@ -95,7 +96,7 @@ module ActsAsTaggableOn::Taggable
 
         else
           tags = ActsAsTaggableOn::Tag.named_any(tag_list)
-          return scoped(:conditions => "1 = 0") unless tags.length == tag_list.length
+          return empty_result unless tags.length == tag_list.length
 
           tags.each do |tag|
             safe_tag = tag.name.gsub(/[^a-zA-Z0-9]/, '')

--- a/spec/acts_as_taggable_on/taggable_spec.rb
+++ b/spec/acts_as_taggable_on/taggable_spec.rb
@@ -251,6 +251,11 @@ describe "Taggable" do
 
     TaggableModel.tagged_with("lazy", :exclude => true).to_a.should == [frank, steve]
   end
+  
+  it "should return an empty scope for empty tags" do
+    TaggableModel.tagged_with('').should == []
+    TaggableModel.tagged_with(' ').should == []
+  end
 
   it "should not create duplicate taggings" do
     bob = TaggableModel.create(:name => "Bob")


### PR DESCRIPTION
Heya - I have a minor fix to tagged_with if you're interested.  It's supposed to return a scope of objects matching the supplied tag.  However, if the tag is blank or a space, it currently returns a hash, which the client probably doesn't expect.

I kept getting hoptoad notifications of errors caused by this (for some reason the Baidu search engine keeps requesting our tags page with a tag named " "...), so finally got around to fixing it.

-Jonathan
