### PR TITLE
Recommended Tags

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+== 2011-05-21
+* Can now find tags recommended for a value of the class or associated (brunoarueira)
+
 == 2010-02-17
 * Converted the plugin to be compatible with Rails3
 

--- a/README.rdoc
+++ b/README.rdoc
@@ -141,6 +141,34 @@ to allow for dynamic tag contexts (this could be user generated tag contexts!)
     @user.tag_counts_on(:customs)
     User.tagged_with("same", :on => :customs) # => [@user]
 
+=== Finding Recommended tags
+
+Now you will find the recommended tags based on associated class:
+
+    class Product < ActiveRecord::Base
+      acts_as_taggable
+
+      has_one :producer
+    end
+
+    class Producer < ActiveRecord::Base
+    end
+
+    @producer = Producer.new(:name => "Strategy Distribution")
+    @producer.save
+
+    @paint = Product.new(:name => "Paint")
+    @paint.producer = @producer
+    @paint.tag_list = "brilliant, awesome, useful"
+    @paint.save
+
+    @tshirt = Product.new(:name => "T-shirt")
+    @tshirt.producer = @producer
+    @tshirt.tag_list = "cool, brilliant, useful"
+    @tshirt.save
+
+    @paint.find_tags_recommended_for(:producer, :name, "Strategy Distribution") # => "brilliant", "useful", "awesome", "cool"
+
 === Tag Ownership
 
 Tags can have owners:

--- a/lib/acts-as-taggable-on.rb
+++ b/lib/acts-as-taggable-on.rb
@@ -11,6 +11,7 @@ require "acts_as_taggable_on/acts_as_taggable_on/collection"
 require "acts_as_taggable_on/acts_as_taggable_on/cache"
 require "acts_as_taggable_on/acts_as_taggable_on/ownership"
 require "acts_as_taggable_on/acts_as_taggable_on/related"
+require "acts_as_taggable_on/acts_as_taggable_on/recommended"
 
 require "acts_as_taggable_on/acts_as_tagger"
 require "acts_as_taggable_on/tag"

--- a/lib/acts_as_taggable_on/acts_as_taggable_on.rb
+++ b/lib/acts_as_taggable_on/acts_as_taggable_on.rb
@@ -46,6 +46,7 @@ module ActsAsTaggableOn
           include ActsAsTaggableOn::Taggable::Cache
           include ActsAsTaggableOn::Taggable::Ownership
           include ActsAsTaggableOn::Taggable::Related
+          include ActsAsTaggableOn::Taggable::Recommended
         end
       end
     end

--- a/lib/acts_as_taggable_on/acts_as_taggable_on/recommended.rb
+++ b/lib/acts_as_taggable_on/acts_as_taggable_on/recommended.rb
@@ -1,0 +1,38 @@
+module ActsAsTaggableOn::Taggable
+  module Recommended
+    def self.included(base)
+      base.send :include, ActsAsTaggableOn::Taggable::Recommended::InstanceMethods
+      base.extend ActsAsTaggableOn::Taggable::Recommended::ClassMethods
+      base.initialize_acts_as_taggable_on_recommended
+    end
+
+    module ClassMethods
+      def initialize_acts_as_taggable_on_recommended
+        tag_types.map(&:to_s).each do |tag_type|
+          class_eval %(
+              def find_#{tag_type}_recommended_for(association_id, attribute_of_association, value)
+                recommended_tags_for(self.class, association_id, attribute_of_association, value)
+              end
+          )
+        end
+      end
+
+      def acts_as_taggable_on(*args)
+        super(*args)
+        initialize_acts_as_taggable_on_recommended
+      end
+    end
+
+    module InstanceMethods
+      def recommended_tags_for(klass, association_id, attribute_of_association, value)
+        klass_association = self.send("#{association_id}").class
+        
+        ActsAsTaggableOn::Tag.scoped({ :select     => "#{ActsAsTaggableOn::Tag.table_name}.name, COUNT(#{ActsAsTaggableOn::Tag.table_name}.*) AS tag_counts",
+                       :from       => "#{klass.table_name}, #{ActsAsTaggableOn::Tag.table_name}, #{ActsAsTaggableOn::Tagging.table_name}, #{klass_association.table_name}",
+                       :conditions => ["#{ActsAsTaggableOn::Tagging.table_name}.taggable_type = '#{klass.to_s}' AND #{ActsAsTaggableOn::Tagging.table_name}.taggable_id = #{klass.table_name}.id AND #{klass_association.table_name}.#{attribute_of_association} = ? AND #{ActsAsTaggableOn::Tag.table_name}.id = #{ActsAsTaggableOn::Tagging.table_name}.tag_id", value],
+                       :group => "#{ActsAsTaggableOn::Tag.table_name}.name HAVING COUNT(*) > 0",
+                       :order      => "tag_counts DESC" })
+      end
+    end
+  end
+end

--- a/spec/acts_as_taggable_on/acts_as_taggable_on_spec.rb
+++ b/spec/acts_as_taggable_on/acts_as_taggable_on_spec.rb
@@ -265,4 +265,28 @@ describe "Acts As Taggable On" do
     end
   end
 
+  describe 'Recommended' do
+    it 'should find recommended tags based on attribute of associated model' do
+      other_taggable1 = OtherTaggableModel.create!(:name => "Taggable 1")
+      other_taggable2 = OtherTaggableModel.create!(:name => "Taggable 2")
+      other_taggable3 = OtherTaggableModel.create!(:name => "Taggable 3")
+
+      untaggable1 = UntaggableModel.create!(:name => "Untaggable 1")
+
+      other_taggable1.tag_list = "one, two"
+      other_taggable1.untaggable_model = untaggable1
+      other_taggable1.save
+  
+      other_taggable2.tag_list = "three, four"
+      other_taggable2.untaggable_model = untaggable1
+      other_taggable2.save
+  
+      other_taggable3.tag_list = "one, four"
+      other_taggable3.untaggable_model = untaggable1
+      other_taggable3.save
+
+      other_taggable1.find_tags_recommended_for(:untaggable_model, :name, 'Untaggable 1').length.should == 4
+    end
+  end
+
 end

--- a/spec/models.rb
+++ b/spec/models.rb
@@ -13,6 +13,8 @@ end
 class OtherTaggableModel < ActiveRecord::Base
   acts_as_taggable_on :tags, :languages
   acts_as_taggable_on :needs, :offerings
+
+  has_one :untaggable_model
 end
 
 class InheritingTaggableModel < TaggableModel
@@ -28,4 +30,5 @@ end
 
 class UntaggableModel < ActiveRecord::Base
   belongs_to :taggable_model
+  belongs_to :other_taggable_model
 end

--- a/spec/schema.rb
+++ b/spec/schema.rb
@@ -24,6 +24,7 @@ ActiveRecord::Schema.define :version => 0 do
   create_table :untaggable_models, :force => true do |t|
     t.column :taggable_model_id, :integer
     t.column :name, :string
+    t.column :other_taggable_model_id, :integer
   end
   
   create_table :cached_models, :force => true do |t|

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -29,7 +29,7 @@ unless [].respond_to?(:freq)
   end
 end
 
-ENV['DB'] ||= 'sqlite3'
+ENV['DB'] ||= 'postgresql'
 
 database_yml = File.expand_path('../database.yml', __FILE__)
 if File.exists?(database_yml)


### PR DESCRIPTION
Add support to find recommended tags using method find_tags_recommended_for, passing three parameters. First parameter is an association to the model has a acts_as_taggable_on with another, the second is the attribute of the model associated and third is a value to find based on attribute of the model associated!
