### PR TITLE
empty tag list ought to return all documents

### DIFF
--- a/spec/acts_as_taggable_on/taggable_spec.rb
+++ b/spec/acts_as_taggable_on/taggable_spec.rb
@@ -193,6 +193,7 @@ describe "Taggable" do
     TaggableModel.tagged_with("ruby", :order => 'taggable_models.name').to_a.should == [bob, frank, steve]
     TaggableModel.tagged_with("ruby, rails", :order => 'taggable_models.name').to_a.should == [bob, frank]
     TaggableModel.tagged_with(["ruby", "rails"], :order => 'taggable_models.name').to_a.should == [bob, frank]
+    TaggableModel.tagged_with([], :order => 'taggable_models.name').to_a.should == [bob, frank, steve]
   end
   
   it "should be able to find tagged with quotation marks" do
@@ -260,7 +261,7 @@ describe "Taggable" do
       bob.save
     }.should change(ActsAsTaggableOn::Tagging, :count).by(1)
   end
- 
+
   describe "Associations" do
     before(:each) do
       @taggable = TaggableModel.create(:tag_list => "awesome, epic")


### PR DESCRIPTION
Given that the interpretation of tagged_with is that it ought to return all documents that match all the tags, an empty tag list ought to return all documents. spec is included.
