### PR TITLE
Preserve the order in which tags are created

### DIFF
--- a/lib/acts_as_taggable_on/acts_as_taggable_on.rb
+++ b/lib/acts_as_taggable_on/acts_as_taggable_on.rb
@@ -14,6 +14,17 @@ module ActsAsTaggableOn
     def acts_as_taggable
       acts_as_taggable_on :tags
     end
+    
+    ##
+    # This is an alias for calling <tt>acts_as_ordered_taggable_on :tags</tt>.
+    #
+    # Example:
+    #   class Book < ActiveRecord::Base
+    #     acts_as_ordered_taggable
+    #   end
+    def acts_as_ordered_taggable
+      acts_as_taggable_on :tags
+    end
 
     ##
     # Make a model taggable on specified contexts.
@@ -25,29 +36,61 @@ module ActsAsTaggableOn
     #     acts_as_taggable_on :languages, :skills
     #   end
     def acts_as_taggable_on(*tag_types)
-      tag_types = tag_types.to_a.flatten.compact.map(&:to_sym)
+      taggable_on(false, tag_types)
+    end
+    
+    ##
+    # Make a model taggable on specified contexts
+    # and preserves the order in which tags are created
+    #
+    # @param [Array] tag_types An array of taggable contexts
+    #
+    # Example:
+    #   class User < ActiveRecord::Base
+    #     acts_as_ordered_taggable_on :languages, :skills
+    #   end
+    def acts_as_ordered_taggable_on(*tag_types)
+      taggable_on(true, tag_types)
+    end
+    
+    private
+    
+      # Make a model taggable on specified contexts
+      # and optionally preserves the order in which tags are created
+      #
+      # Seperate methods used above for backwards compatibility
+      # so that the original acts_as_taggable_on is unaffected
+      # as it's not possible to add another arguement to the method
+      # without the tag_types being enclosed in square brackets
+      #
+      def taggable_on(preserve_tag_order, *tag_types)
+        tag_types = tag_types.to_a.flatten.compact.map(&:to_sym)
 
-      if taggable?
-        write_inheritable_attribute(:tag_types, (self.tag_types + tag_types).uniq)
-      else
-        write_inheritable_attribute(:tag_types, tag_types)
-        class_inheritable_reader(:tag_types)
-        
-        class_eval do
-          has_many :taggings, :as => :taggable, :dependent => :destroy, :include => :tag, :class_name => "ActsAsTaggableOn::Tagging"
-          has_many :base_tags, :through => :taggings, :source => :tag, :class_name => "ActsAsTaggableOn::Tag"
+        if taggable?
+          write_inheritable_attribute(:tag_types, (self.tag_types + tag_types).uniq)
+          write_inheritable_attribute(:preserve_tag_order?, preserve_tag_order)
+        else
+          write_inheritable_attribute(:tag_types, tag_types)
+          write_inheritable_attribute(:preserve_tag_order?, preserve_tag_order)
+          class_inheritable_reader(:tag_types)
+          class_inheritable_reader(:preserve_tag_order?)
 
-          def self.taggable?
-            true
+          class_eval do
+            has_many :taggings, :as => :taggable, :dependent => :destroy, :include => :tag, :class_name => "ActsAsTaggableOn::Tagging"
+            has_many :base_tags, :through => :taggings, :source => :tag, :class_name => "ActsAsTaggableOn::Tag"
+
+            def self.taggable?
+              true
+            end
+
+            include ActsAsTaggableOn::Taggable::Core
+            include ActsAsTaggableOn::Taggable::Collection
+            include ActsAsTaggableOn::Taggable::Cache
+            include ActsAsTaggableOn::Taggable::Ownership
+            include ActsAsTaggableOn::Taggable::Related
           end
-        
-          include ActsAsTaggableOn::Taggable::Core
-          include ActsAsTaggableOn::Taggable::Collection
-          include ActsAsTaggableOn::Taggable::Cache
-          include ActsAsTaggableOn::Taggable::Ownership
-          include ActsAsTaggableOn::Taggable::Related
         end
       end
-    end
+       
   end
 end

--- a/lib/acts_as_taggable_on/acts_as_taggable_on/core.rb
+++ b/lib/acts_as_taggable_on/acts_as_taggable_on/core.rb
@@ -18,11 +18,21 @@ module ActsAsTaggableOn::Taggable
           tag_type         = tags_type.to_s.singularize
           context_taggings = "#{tag_type}_taggings".to_sym
           context_tags     = tags_type.to_sym
+          taggings_order   = (preserve_tag_order? ? "#{ActsAsTaggableOn::Tagging.table_name}.created_at" : nil)
 
           class_eval do
-            has_many context_taggings, :as => :taggable, :dependent => :destroy, :include => :tag, :class_name => "ActsAsTaggableOn::Tagging",
-            :conditions => ["#{ActsAsTaggableOn::Tagging.table_name}.tag_id = #{ActsAsTaggableOn::Tag.table_name}.id AND #{ActsAsTaggableOn::Tagging.table_name}.context = ?", tags_type]
-            has_many context_tags, :through => context_taggings, :source => :tag, :class_name => "ActsAsTaggableOn::Tag"
+            # when preserving tag order, include order option so that for a 'tags' context
+            # the associations tag_taggings & tags are always returned in created order
+            has_many context_taggings, 
+              :as => :taggable, :dependent => :destroy, 
+              :include => :tag, :class_name => "ActsAsTaggableOn::Tagging",
+              :conditions => ["#{ActsAsTaggableOn::Tagging.table_name}.tag_id = #{ActsAsTaggableOn::Tag.table_name}.id AND #{ActsAsTaggableOn::Tagging.table_name}.context = ?", tags_type],
+              :order => taggings_order
+            has_many context_tags,
+              :through => context_taggings,
+              :source => :tag,
+              :class_name => "ActsAsTaggableOn::Tag",
+              :order => taggings_order
           end
 
           class_eval %(
@@ -204,7 +214,11 @@ module ActsAsTaggableOn::Taggable
       ##
       # Returns all tags that are not owned of a given context
       def tags_on(context)
-        base_tags.where(["#{ActsAsTaggableOn::Tagging.table_name}.context = ? AND #{ActsAsTaggableOn::Tagging.table_name}.tagger_id IS NULL", context.to_s]).all
+        scope = base_tags.where(["#{ActsAsTaggableOn::Tagging.table_name}.context = ? AND #{ActsAsTaggableOn::Tagging.table_name}.tagger_id IS NULL", context.to_s])
+        # when preserving tag order, return tags in created order
+        # if we added the order to the association this would always apply
+        scope = scope.order("#{ActsAsTaggableOn::Tagging.table_name}.created_at") if self.class.preserve_tag_order?
+        scope.all
       end
 
       def set_tag_list_on(context, new_list)
@@ -231,21 +245,38 @@ module ActsAsTaggableOn::Taggable
         tagging_contexts.each do |context|
           next unless tag_list_cache_set_on(context)
 
+          # List of currently assigned tag names
           tag_list = tag_list_cache_on(context).uniq
 
           # Find existing tags or create non-existing tags:
-          tag_list = ActsAsTaggableOn::Tag.find_or_create_all_with_like_by_name(tag_list)
+          tags = ActsAsTaggableOn::Tag.find_or_create_all_with_like_by_name(tag_list)
 
+          # Tag objects for currently assigned tags
           current_tags = tags_on(context)
-          old_tags     = current_tags - tag_list
-          new_tags     = tag_list     - current_tags
+          
+          # Tag maintenance based on whether preserving the created order of tags
+          if self.class.preserve_tag_order?
+            # First off order the array of tag objects to match the tag list
+            # rather than existing tags followed by new tags
+            tags = tag_list.map{|l| tags.detect{|t| t.name.downcase == l.downcase}}
+            # To preserve tags in the order in which they were added
+            # delete all current tags and create new tags if the content or order has changed
+            old_tags = (tags == current_tags ? [] : current_tags)
+            new_tags = (tags == current_tags ? [] : tags)
+          else
+            # Delete discarded tags and create new tags
+            old_tags = current_tags - tags
+            new_tags = tags - current_tags
+          end
           
           # Find taggings to remove:
-          old_taggings = taggings.where(:tagger_type => nil, :tagger_id => nil,
-                                        :context => context.to_s, :tag_id => old_tags).all
-
+          if old_tags.present?
+            old_taggings = taggings.where(:tagger_type => nil, :tagger_id => nil,
+                                          :context => context.to_s, :tag_id => old_tags).all
+          end
+          
+          # Destroy old taggings:
           if old_taggings.present?
-            # Destroy old taggings:
             ActsAsTaggableOn::Tagging.destroy_all :id => old_taggings.map(&:id)
           end
 

--- a/spec/acts_as_taggable_on/acts_as_taggable_on_spec.rb
+++ b/spec/acts_as_taggable_on/acts_as_taggable_on_spec.rb
@@ -8,6 +8,19 @@ describe "Acts As Taggable On" do
   it "should provide a class method 'taggable?' that is false for untaggable models" do
     UntaggableModel.should_not be_taggable
   end
+  
+  describe "Taggable Method Generation To Preserve Order" do
+    before(:each) do
+      clean_database!
+      TaggableModel.write_inheritable_attribute(:tag_types, [])
+      TaggableModel.acts_as_ordered_taggable_on(:ordered_tags)
+      @taggable = TaggableModel.new(:name => "Bob Jones")
+    end
+
+    it "should respond 'true' to preserve_tag_order?" do
+      @taggable.class.preserve_tag_order?.should be_true
+    end
+  end
 
   describe "Taggable Method Generation" do
     before(:each) do
@@ -32,6 +45,18 @@ describe "Acts As Taggable On" do
     it "should have all tag types" do
       @taggable.tag_types.should == [:tags, :languages, :skills, :needs, :offerings]
     end
+    
+    it "should create a class attribute for preserve tag order" do
+      @taggable.class.should respond_to(:preserve_tag_order?)
+    end
+
+    it "should create an instance attribute for preserve tag order" do
+      @taggable.should respond_to(:preserve_tag_order?)
+    end
+    
+    it "should respond 'false' to preserve_tag_order?" do
+      @taggable.class.preserve_tag_order?.should be_false
+    end
 
     it "should generate an association for each tag type" do
       @taggable.should respond_to(:tags, :skills, :languages)
@@ -50,7 +75,7 @@ describe "Acts As Taggable On" do
       @taggable.should respond_to(:all_tags_list, :all_skills_list, :all_languages_list)
     end
   end
-
+  
   describe "Single Table Inheritance" do
     before do
       @taggable = TaggableModel.new(:name => "taggable")


### PR DESCRIPTION
This commit adds acts_as_ordered_taggable methods to use when you want to preserve the order in which tags are created.

For example, using the new methods means that when an object's tag_list is updated from [4,5,6] to [3,6,9] a subsequent fetch of the object's tag_list will return [3,6,9] and also the tags association will return tag objects in the same order. 

The new methods set the attribute preserve_tag_order? to true and consequently (1) when saving tags, the taggings are created in the order in which the tags appear in the tag list; (2) when fetching tags by context for the tag lists they are ordered by tagging created_at; (3) an order option is added to the tag context associations (so that for a 'tags' context the associations tag_taggings & tags are always returned in tagging created_at order)
