### PR TITLE
Clarify ownership with a few more examples. RE: object.tags returning [] due to NULL in join

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -159,8 +159,10 @@ Tags can have owners:
     @some_user.tag(@some_photo, :with => "paris, normandy", :on => :locations)
     @some_user.owned_taggings
     @some_user.owned_tags
-    @some_photo.locations_from(@some_user)
-    
+    @some_photo.locations_from(@some_user) # => ["paris", "normandy"]
+    @some_photo.owner_tags_on(@some_user, :locations) # => [#<ActsAsTaggableOn::Tag id: 1, name: "paris">...]
+    @some_photo.owner_tags_on(nil, :locations) # => Ownerships equivalent to saying @some_photo.locations
+
 === Tag cloud calculations
 
 To construct tag clouds, the frequency of each tag needs to be calculated.


### PR DESCRIPTION
There seems to be a lot of confusion with ownership, see below for discussions. Adding some examples to save people some time from searching through issues/source. 

https://github.com/mbleigh/acts-as-taggable-on/issues/76
https://github.com/mbleigh/acts-as-taggable-on/commit/3d707c25d45b5cc680cf3623d15ff59856457ea9#lib/acts_as_taggable_on/acts_as_taggable_on/ownership.rb
https://github.com/mbleigh/acts-as-taggable-on/issues/52
