### PR TITLE
Postgres fix for tagged_with

### DIFF
--- a/lib/acts_as_taggable_on/acts_as_taggable_on/core.rb
+++ b/lib/acts_as_taggable_on/acts_as_taggable_on/core.rb
@@ -100,7 +100,7 @@ module ActsAsTaggableOn::Taggable
 
           # don't need to sanitize sql, map all ids and join with OR logic
           conditions << tags.map { |t| "#{taggings_alias}.tag_id = #{t.id}" }.join(" OR ")
-          select_clause = "DISTINCT \"#{table_name}\".*" unless context and tag_types.one?
+          select_clause = "DISTINCT  \"#{table_name}\".*" unless context and tag_types.one?
 
           joins << tagging_join
 


### PR DESCRIPTION
Rails 3.1 on Heroku cedar stack. Postgres wants table names to be quoted in the tagged_with query. Sample error:

```

irb(main):005:0> c =Reference.tagged_with("stages")
  ActsAsTaggableOn::Tag Load (32.1ms)  SELECT "tags".* FROM "tags" WHERE (name ILIKE 'stages')
  Reference Load (2.1ms)  SELECT "references".* FROM "references" JOIN taggings references_taggings_stages_512 ON references_taggings_stages_512.taggable_id = references.id AND references_taggings_stages_512.taggable_type = 'Reference' AND references_taggings_stages_512.tag_id = 1
ActiveRecord::StatementInvalid: PGError: ERROR:  syntax error at or near "references"
LINE 1: ...  ON references_taggings_stages_512.taggable_id = references...
                                                             ^
```
