### PR TITLE
all_tag_counts optimization

### DIFF
--- a/lib/acts_as_taggable_on/acts_as_taggable_on/collection.rb
+++ b/lib/acts_as_taggable_on/acts_as_taggable_on/collection.rb
@@ -113,11 +113,19 @@ module ActsAsTaggableOn::Taggable
         group_columns = "#{ActsAsTaggableOn::Tagging.table_name}.tag_id"
 
         if ActiveRecord::VERSION::MAJOR >= 3
-          # Merge the current scope to the scope
           current_scope = scoped {}
-          tagging_scope = tagging_scope.merge(current_scope).
-                                        group(group_columns).
-                                        having(having)
+          
+          if current_scope.group_values.empty?
+            # Merge the current scope to the scope
+            current_scope = scoped {}
+            tagging_scope = tagging_scope.merge(current_scope)
+          else
+            # Append the current scope to the scope, because we can't use scope(:find) in RoR 3.0 anymore:
+            scoped_select = "#{table_name}.#{primary_key}"
+            tagging_scope = tagging_scope.where("#{ActsAsTaggableOn::Tagging.table_name}.taggable_id IN(#{select(scoped_select).to_sql})")
+          end
+          
+          tagging_scope = tagging_scope.group(group_columns).having(having)
         else
           # Having is not available in 2.3.x:
           group_by  = "#{group_columns} HAVING COUNT(*) > 0"


### PR DESCRIPTION
Hi dear taggables, 

After switching to Rails 3 we got some extremely slow query when calling all_tag_counts on big taggables tables. The main cause seems to be the subselect introduced cause "we can't use scope(:find) in RoR 3.0 anymore":

```
scoped_select = "#{table_name}.#{primary_key}"
scope = scope.where("#{ActsAsTaggableOn::Tagging.table_name}.taggable_id IN(#{select(scoped_select).to_sql})")
```

However, Rails 3 provide a merge method for scope, that i tried to integrate here:

```
current_scope = scoped {}
scope = scope.merge(current_scope)
```

The performance improvement is hudge (x500) in case of big database (60.000 taggables, 400.000 taggings).

Example generated query before patch:

> SELECT tags._, COUNT(_) AS count FROM tags LEFT OUTER JOIN taggings ON tags.id = taggings.tag_id INNER JOIN articles ON articles.id = taggings.taggable_id WHERE (taggings.taggable_type = 'Article') AND (taggings.taggable_id IN(SELECT articles.id FROM articles WHERE articles.deleted = 0 AND (articles.state IN ('accepted')))) GROUP BY tags.id, tags.name HAVING COUNT(*) > 0 LIMIT 20;
> 20 rows in set (22.06 sec)

Same query after patch:

> SELECT tags._, COUNT(_) AS count FROM tags LEFT OUTER JOIN taggings ON tags.id = taggings.tag_id INNER JOIN articles ON articles.id = taggings.taggable_id WHERE (taggings.taggable_type = 'Article') AND (articles.deleted = 0 AND articles.state IN ('accepted')) GROUP BY tags.id, tags.name HAVING COUNT(*) > 0 LIMIT 20;
> 20 rows in set (0.04 sec)

However, there seems to be a side-effect as one of the spec fails.

```
rspec ./spec/acts_as_taggable_on/taggable_spec.rb:178 # Taggable should only return tag counts for the available scope

Failure/Error: TaggableModel.tagged_with('rails').scoped(:joins => :untaggable_models).all_tag_counts.should have(2).items
ActiveRecord::ConfigurationError:
Association named 'untaggable_models' was not found; perhaps you misspelled it?
```

Maybe the patch is not complete, but i hope the idea could help a bit.

Kind regards,
Guillaume
