### PR TITLE
Ensure tag_cloud can handle tags with zero taggings.

### DIFF
--- a/lib/acts_as_taggable_on/tags_helper.rb
+++ b/lib/acts_as_taggable_on/tags_helper.rb
@@ -9,8 +9,8 @@ module ActsAsTaggableOn
       max_count = tags.sort_by(&:count).last.count.to_f
 
       tags.each do |tag|
-        index = ((tag.count / max_count) * (classes.size - 1)).round
-        yield tag, classes[index]
+        index = ((tag.count / max_count) * (classes.size - 1))
+        yield tag, classes[index.nan? ? 0 : index.round]
       end
     end
   end

--- a/spec/acts_as_taggable_on/tags_helper_spec.rb
+++ b/spec/acts_as_taggable_on/tags_helper_spec.rb
@@ -25,4 +25,20 @@ describe ActsAsTaggableOn::TagsHelper do
     tags["c++"].should == "sucky"
     tags["php"].should == "sucky"
   end
+  
+  it "should handle tags with zero counts (build for empty)" do
+    bob = ActsAsTaggableOn::Tag.create(:name => "php")
+    tom = ActsAsTaggableOn::Tag.create(:name => "java")
+    eve = ActsAsTaggableOn::Tag.create(:name => "c++")
+    
+    tags = { }
+    
+    @helper.tag_cloud(ActsAsTaggableOn::Tag.all, ["sucky", "awesome"]) do |tag, css_class|
+      tags[tag.name] = css_class
+    end
+    
+    tags["java"].should == "sucky"
+    tags["c++"].should == "sucky"
+    tags["php"].should == "sucky"
+  end
 end


### PR DESCRIPTION
I came across a situation where a tag with no remaining taggings was raising;

```
     FloatDomainError:
       NaN
     # ./lib/acts_as_taggable_on/tags_helper.rb:12:in `round'
     # ./lib/acts_as_taggable_on/tags_helper.rb:12:in `block in tag_cloud'
     # ./lib/acts_as_taggable_on/tags_helper.rb:11:in `each'
     # ./lib/acts_as_taggable_on/tags_helper.rb:11:in `tag_cloud'
```

This fixes it.
