### PR TITLE
Fixed all_tag_counts crashing when using a table prefix

### DIFF
--- a/lib/acts_as_taggable_on/acts_as_taggable_on/collection.rb
+++ b/lib/acts_as_taggable_on/acts_as_taggable_on/collection.rb
@@ -125,7 +125,7 @@ module ActsAsTaggableOn::Taggable
           tagging_scope = tagging_scope.group(group_by)
         end
 
-        tag_scope = tag_scope.joins("JOIN (#{tagging_scope.to_sql}) AS taggings ON taggings.tag_id = tags.id")
+        tag_scope = tag_scope.joins("JOIN (#{tagging_scope.to_sql}) AS #{ActsAsTaggableOn::Tagging.table_name} ON #{ActsAsTaggableOn::Tagging.table_name}.tag_id = #{ActsAsTaggableOn::Tag.table_name}.id")
         tag_scope
       end
     end


### PR DESCRIPTION
I use a table prefix in my production environment and found that the tag_cloud function caused one of my pages to throw an ActiveRecord::StatementInvalid exception instead of loading. I found that the reason this was was because all_tag_counts, at the end, uses some SQL that doesn't take into effect the possibility that a table prefix may be being used.
