### PR TITLE
add escaping % and _ for like operator in sqlite by specifying escape character

### DIFF
--- a/lib/acts_as_taggable_on/tag.rb
+++ b/lib/acts_as_taggable_on/tag.rb
@@ -17,19 +17,19 @@ module ActsAsTaggableOn
     ### SCOPES:
     
     def self.named(name)
-      where(["name #{like_operator} ?", escape_like(name)])
+      where(["name #{like_operator} ? escape '\\'", escape_like(name)])
     end
   
     def self.named_any(list)
-      where(list.map { |tag| sanitize_sql(["name #{like_operator} ?", escape_like(tag.to_s)]) }.join(" OR "))
+      where(list.map { |tag| sanitize_sql(["name #{like_operator} ? escape '\\'", escape_like(tag.to_s)]) }.join(" OR "))
     end
   
     def self.named_like(name)
-      where(["name #{like_operator} ?", "%#{escape_like(name)}%"])
+      where(["name #{like_operator} ? escape '\\'", "%#{escape_like(name)}%"])
     end
 
     def self.named_like_any(list)
-      where(list.map { |tag| sanitize_sql(["name #{like_operator} ?", "%#{escape_like(tag.to_s)}%"]) }.join(" OR "))
+      where(list.map { |tag| sanitize_sql(["name #{like_operator} ? escape '\\'", "%#{escape_like(tag.to_s)}%"]) }.join(" OR "))
     end
 
     ### CLASS METHODS:

--- a/lib/acts_as_taggable_on/utils.rb
+++ b/lib/acts_as_taggable_on/utils.rb
@@ -11,20 +11,15 @@ module ActsAsTaggableOn
         ::ActiveRecord::Base.connection && ::ActiveRecord::Base.connection.adapter_name == 'PostgreSQL'
       end
       
-      def using_sqlite?
-        ::ActiveRecord::Base.connection && ::ActiveRecord::Base.connection.adapter_name == 'SQLite'
-      end 
-        
       private
       def like_operator
         using_postgresql? ? 'ILIKE' : 'LIKE'
       end
       
       # escape _ and % characters in strings, since these are wildcards in SQL.
-       def escape_like(str)
-         return str if using_sqlite? # skip escaping for SQLite
-         str.to_s.gsub("_", "\\\_").gsub("%", "\\\%")
-       end
+      def escape_like(str)
+        str.to_s.gsub("_", "\\\_").gsub("%", "\\\%")
+      end
     end
 
   end

--- a/spec/acts_as_taggable_on/tag_spec.rb
+++ b/spec/acts_as_taggable_on/tag_spec.rb
@@ -123,13 +123,8 @@ describe ActsAsTaggableOn::Tag do
     end
     
     it "return escaped result when '%' char present in tag" do
-      if @tag.using_sqlite?
-        ActsAsTaggableOn::Tag.named_like('coo%').should include(@tag)     
-        ActsAsTaggableOn::Tag.named_like('coo%').should include(@another_tag)
-      else
-        ActsAsTaggableOn::Tag.named_like('coo%').should_not include(@tag)     
-        ActsAsTaggableOn::Tag.named_like('coo%').should include(@another_tag)
-      end
+      ActsAsTaggableOn::Tag.named_like('coo%').should_not include(@tag)     
+      ActsAsTaggableOn::Tag.named_like('coo%').should include(@another_tag)
     end
     
   end


### PR DESCRIPTION
A modification on ecc1af9a9f90c13d9a19ce9a6d4bcb7d9860dd02 (issue #127, #135) to add support for sqlite.
