### PR TITLE
Change gemspec to rails ~> 3.0

### DIFF
--- a/acts-as-taggable-on.gemspec
+++ b/acts-as-taggable-on.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |gem|
   gem.email = %q{michael@intridea.com}
   gem.homepage      = ''
 
-  gem.add_runtime_dependency 'rails', '~> 3.1'
+  gem.add_runtime_dependency 'rails', '~> 3.0'
   gem.add_development_dependency 'rspec', '~> 2.5'
   gem.add_development_dependency 'ammeter', '~> 0.1.3'
   gem.add_development_dependency 'sqlite3'


### PR DESCRIPTION
From both my tests and the README the latest 2.2.x version of acts_as_taggable_on is compatible with Rails 3.0.x.  This pull moves the gem dependency down to ~> 3.0 instead of 3.1.  If it's actually not compatible in some way with 3.0.x you might want to update the README to reflect that.

Thanks.
