### PR TITLE
Added basic unicode support. Fixes #204

### DIFF
--- a/lib/acts_as_taggable_on/acts_as_taggable_on/core.rb
+++ b/lib/acts_as_taggable_on/acts_as_taggable_on/core.rb
@@ -103,7 +103,7 @@ module ActsAsTaggableOn::Taggable
           # avoid ambiguous column name
           taggings_context = context ? "_#{context}" : ''
 
-          taggings_alias   = "#{alias_base_name[0..4]}#{taggings_context[0..6]}_taggings_#{sha_prefix(tags.map(&:safe_name).join('_'))}"
+          taggings_alias   = "#{alias_base_name[0..4]}#{taggings_context[0..6]}_taggings_#{sha_prefix(tags.map(&:name).join('_'))}"
 
           tagging_join  = "JOIN #{ActsAsTaggableOn::Tagging.table_name} #{taggings_alias}" +
                           "  ON #{taggings_alias}.taggable_id = #{table_name}.#{primary_key}" +
@@ -122,7 +122,7 @@ module ActsAsTaggableOn::Taggable
 
           tags.each do |tag|
 
-            taggings_alias = "#{alias_base_name[0..11]}_taggings_#{sha_prefix(tag.safe_name)}"
+            taggings_alias = "#{alias_base_name[0..11]}_taggings_#{sha_prefix(tag.name)}"
 
             tagging_join  = "JOIN #{ActsAsTaggableOn::Tagging.table_name} #{taggings_alias}" +
                             "  ON #{taggings_alias}.taggable_id = #{table_name}.#{primary_key}" +

--- a/lib/acts_as_taggable_on/tag.rb
+++ b/lib/acts_as_taggable_on/tag.rb
@@ -66,14 +66,10 @@ module ActsAsTaggableOn
       read_attribute(:count).to_i
     end
 
-    def safe_name
-      name.gsub(/[^a-zA-Z0-9]/, '')
-    end
-
     class << self
       private
         def comparable_name(str)
-          RUBY_VERSION >= "1.9" ? str.downcase : str.mb_chars.downcase
+          str.mb_chars.downcase.to_s
         end
     end
   end

--- a/lib/acts_as_taggable_on/utils.rb
+++ b/lib/acts_as_taggable_on/utils.rb
@@ -16,7 +16,7 @@ module ActsAsTaggableOn
       end
 
       def sha_prefix(string)
-        Digest::SHA1.hexdigest(string + Time.now.to_s)[0..6]
+        Digest::SHA1.hexdigest("#{string}#{rand}")[0..6]
       end
       
       private

--- a/spec/acts_as_taggable_on/tag_spec.rb
+++ b/spec/acts_as_taggable_on/tag_spec.rb
@@ -1,3 +1,5 @@
+#encoding: utf-8
+
 require File.expand_path('../../spec_helper', __FILE__)
 
 describe ActsAsTaggableOn::Tag do
@@ -37,6 +39,23 @@ describe ActsAsTaggableOn::Tag do
       lambda {
         ActsAsTaggableOn::Tag.find_or_create_with_like_by_name("epic")
       }.should change(ActsAsTaggableOn::Tag, :count).by(1)
+    end
+  end
+
+  unless ActsAsTaggableOn::Tag.using_sqlite?
+    describe "find or create by unicode name" do
+      before(:each) do
+        @tag.name = "привет"
+        @tag.save
+      end
+
+      it "should find by name" do
+        ActsAsTaggableOn::Tag.find_or_create_with_like_by_name("привет").should == @tag
+      end
+
+      it "should find by name case insensitive" do
+        ActsAsTaggableOn::Tag.find_or_create_with_like_by_name("ПРИВЕТ").should == @tag
+      end
     end
   end
 


### PR DESCRIPTION
- Even ruby 1.9.3-p0 doesn't downcase non ASCII chars. So we still need String#mb_chars call in Tag#comparable_name
- Replaced Time.now.to_s in Utils#sha_prefix with rand since seconds precision doesn't make sense (Ruby is super fast :).
- Removed Tag#safe_name since it used only with Utils#sha_prefix, but turn all non ASCII tags to empty strings.
