### PR TITLE
use equality comparisons where possible

### DIFF
--- a/lib/acts_as_taggable_on/tag.rb
+++ b/lib/acts_as_taggable_on/tag.rb
@@ -16,11 +16,11 @@ module ActsAsTaggableOn
     ### SCOPES:
 
     def self.named(name)
-      where(["name #{like_operator} ? ESCAPE '!'", escape_like(name)])
+      where(["lower(name) = ?", name.downcase])
     end
 
     def self.named_any(list)
-      where(list.map { |tag| sanitize_sql(["name #{like_operator} ? ESCAPE '!'", escape_like(tag.to_s)]) }.join(" OR "))
+      where(list.map { |tag| sanitize_sql(["lower(name) = ?", tag.to_s.downcase]) }.join(" OR "))
     end
 
     def self.named_like(name)


### PR DESCRIPTION
ILIKE queries in Postgresql can't use an index and are unnecessary in these simple cases.

All tests pass for all three databases.
