### PR TITLE
Fixes for acts_as_ordered_taggable

### DIFF
--- a/lib/acts_as_taggable_on/acts_as_taggable_on/core.rb
+++ b/lib/acts_as_taggable_on/acts_as_taggable_on/core.rb
@@ -52,11 +52,11 @@ module ActsAsTaggableOn::Taggable
         end
       end
 
-      def acts_as_taggable_on(*args)
-        super(*args)
+      def taggable_on(preserve_tag_order, *tag_types)
+        super(preserve_tag_order, *tag_types)
         initialize_acts_as_taggable_on_core
       end
-
+      
       # all column names are necessary for PostgreSQL group clause
       def grouped_column_names_for(object)
         object.column_names.map { |column| "#{object.table_name}.#{column}" }.join(", ")

--- a/lib/acts_as_taggable_on/taggable.rb
+++ b/lib/acts_as_taggable_on/taggable.rb
@@ -64,6 +64,9 @@ module ActsAsTaggableOn
       # as it's not possible to add another arguement to the method
       # without the tag_types being enclosed in square brackets
       #
+      # NB: method overridden in core module in order to create tag type
+      #     associations and methods after this logic has executed
+      #
       def taggable_on(preserve_tag_order, *tag_types)
         tag_types = tag_types.to_a.flatten.compact.map(&:to_sym)
 

--- a/spec/acts_as_taggable_on/acts_as_taggable_on_spec.rb
+++ b/spec/acts_as_taggable_on/acts_as_taggable_on_spec.rb
@@ -13,6 +13,7 @@ describe "Acts As Taggable On" do
     before(:each) do
       clean_database!
       TaggableModel.tag_types = []
+      TaggableModel.preserve_tag_order = false
       TaggableModel.acts_as_ordered_taggable_on(:ordered_tags)
       @taggable = TaggableModel.new(:name => "Bob Jones")
     end

--- a/spec/models.rb
+++ b/spec/models.rb
@@ -42,3 +42,8 @@ class NonStandardIdTaggableModel < ActiveRecord::Base
   acts_as_taggable_on :needs, :offerings
   has_many :untaggable_models
 end
+
+class OrderedTaggableModel < ActiveRecord::Base
+  acts_as_ordered_taggable
+  acts_as_ordered_taggable_on :colours
+end

--- a/spec/schema.rb
+++ b/spec/schema.rb
@@ -53,4 +53,9 @@ ActiveRecord::Schema.define :version => 0 do
     t.column :name, :string
     t.column :type, :string
   end
+  
+  create_table :ordered_taggable_models, :force => true do |t|
+    t.column :name, :string
+    t.column :type, :string
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -31,6 +31,8 @@ unless [].respond_to?(:freq)
   end
 end
 
+# set adapter to use, default is sqlite3
+# to use an alternative adapter run => rake spec DB='postgresql'
 db_name = ENV['DB'] || 'sqlite3'
 database_yml = File.expand_path('../database.yml', __FILE__)
 
@@ -72,7 +74,7 @@ end
 
 def clean_database!
   models = [ActsAsTaggableOn::Tag, ActsAsTaggableOn::Tagging, TaggableModel, OtherTaggableModel, InheritingTaggableModel,
-            AlteredInheritingTaggableModel, TaggableUser, UntaggableModel]
+            AlteredInheritingTaggableModel, TaggableUser, UntaggableModel, OrderedTaggableModel]
   models.each do |model|
     ActiveRecord::Base.connection.execute "DELETE FROM #{model.table_name}"
   end


### PR DESCRIPTION
1. ensure that tag associations & methods are created via core module when a model includes multiple calls to acts_as_ordered_taggable
2. better tests
