### PR TITLE
Close #242

### DIFF
--- a/lib/acts_as_taggable_on/acts_as_taggable_on/core.rb
+++ b/lib/acts_as_taggable_on/acts_as_taggable_on/core.rb
@@ -164,7 +164,6 @@ module ActsAsTaggableOn::Taggable
 
           group_columns = ActsAsTaggableOn::Tag.using_postgresql? ? grouped_column_names_for(self) : "#{table_name}.#{primary_key}"
           group = group_columns
-          group = "#{group_columns}"
           having = "COUNT(#{taggings_alias}.taggable_id) = #{tags.size}"
         end
 


### PR DESCRIPTION
See https://github.com/mbleigh/acts-as-taggable-on/issues/242

Rails blows up if anything other than column name is given explicitly in the group option. I've changed this to use the `having` method. This is the correct use of the AR query API.

I've also added a failing test in my own rails fork that demonstrates the issue:
https://github.com/twinturbo/rails/commit/0ba423444346f3bf76cd631c72839c11d98bf674
