### PR TITLE
BugFix : Enclose the table name with ` for tag_counts_on mysql2 error

### DIFF
--- a/lib/acts_as_taggable_on/acts_as_taggable_on/collection.rb
+++ b/lib/acts_as_taggable_on/acts_as_taggable_on/collection.rb
@@ -77,7 +77,7 @@ module ActsAsTaggableOn::Taggable
         ].compact.reverse
         
         ## Generate joins:
-        taggable_join = "INNER JOIN #{table_name} ON #{table_name}.#{primary_key} = #{ActsAsTaggableOn::Tagging.table_name}.taggable_id"
+        taggable_join = "INNER JOIN `#{table_name}` ON #{table_name}.#{primary_key} = #{ActsAsTaggableOn::Tagging.table_name}.taggable_id"
         taggable_join << " AND #{table_name}.#{inheritance_column} = '#{name}'" unless descends_from_active_record? # Current model is STI descendant, so add type checking to the join condition      
 
         tagging_joins = [


### PR DESCRIPTION
Update table name enclosed with ` which resolves SQL error in the case of special table name.
