### PR TITLE
support for multi delimiters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ spec/database.yml
 tmp*.sw?
 *.sw?
 tmp
+*.gem

--- a/lib/acts-as-taggable-on.rb
+++ b/lib/acts-as-taggable-on.rb
@@ -20,7 +20,8 @@ module ActsAsTaggableOn
   self.remove_unused_tags = false
 
   def self.glue
-    @@delimiter.ends_with?(" ") ? @@delimiter : "#{@@delimiter} "
+    delimiter = @@delimiter.kind_of?(Array) ? @@delimiter[0] : @@delimiter
+    delimiter.ends_with?(" ") ? delimiter : "#{delimiter} "
   end
 
   def self.setup

--- a/lib/acts_as_taggable_on/tag_list.rb
+++ b/lib/acts_as_taggable_on/tag_list.rb
@@ -21,10 +21,12 @@ module ActsAsTaggableOn
         string = string.to_s.dup
 
         # Parse the quoted tags
-        string.gsub!(/(\A|#{ActsAsTaggableOn.delimiter})\s*"(.*?)"\s*(#{ActsAsTaggableOn.delimiter}\s*|\z)/) { tag_list << $2; $3 }
-        string.gsub!(/(\A|#{ActsAsTaggableOn.delimiter})\s*'(.*?)'\s*(#{ActsAsTaggableOn.delimiter}\s*|\z)/) { tag_list << $2; $3 }
+        d = ActsAsTaggableOn.delimiter
+        d = d.join("|") if d.kind_of?(Array) 
+        string.gsub!(/(\A|#{d})\s*"(.*?)"\s*(#{d}\s*|\z)/) { tag_list << $2; $3 }
+        string.gsub!(/(\A|#{d})\s*'(.*?)'\s*(#{d}\s*|\z)/) { tag_list << $2; $3 }
 
-        tag_list.add(string.split(ActsAsTaggableOn.delimiter))
+        tag_list.add(string.split(Regexp.new d))
       end
     end
 
@@ -67,7 +69,9 @@ module ActsAsTaggableOn
       tags.send(:clean!)
 
       tags.map do |name|
-        name.include?(ActsAsTaggableOn.delimiter) ? "\"#{name}\"" : name
+        d = ActsAsTaggableOn.delimiter
+        d = Regexp.new d.join("|") if d.kind_of? Array
+        name.index(d) ? "\"#{name}\"" : name
       end.join(ActsAsTaggableOn.glue)
     end
 

--- a/spec/acts_as_taggable_on/tag_list_spec.rb
+++ b/spec/acts_as_taggable_on/tag_list_spec.rb
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 require File.expand_path('../../spec_helper', __FILE__)
 
 describe ActsAsTaggableOn::TagList do
@@ -90,4 +91,36 @@ describe ActsAsTaggableOn::TagList do
     end
 
   end
+
+  describe "Multiple Delimiter" do
+    before do 
+      @old_delimiter = ActsAsTaggableOn.delimiter
+    end
+
+    after do 
+      ActsAsTaggableOn.delimiter = @old_delimiter
+    end
+
+    it "should separate tags by delimiters" do
+      ActsAsTaggableOn.delimiter = [',', ' ', '\|']
+      tag_list = ActsAsTaggableOn::TagList.from "cool, data|I have"
+      tag_list.to_s.should == 'cool, data, I, have'
+    end
+
+    it "should escape quote" do 
+      ActsAsTaggableOn.delimiter = [',', ' ', '\|']
+      tag_list = ActsAsTaggableOn::TagList.from "'I have'|cool, data"
+      tag_list.to_s.should == '"I have", cool, data'
+
+      tag_list = ActsAsTaggableOn::TagList.from '"I, have"|cool, data'
+      tag_list.to_s.should == '"I, have", cool, data'
+    end
+
+    it "should work for utf8 delimiter and long delimiter" do 
+      ActsAsTaggableOn.delimiter = ['，', '的', '可能是']
+      tag_list = ActsAsTaggableOn::TagList.from "我的东西可能是不见了，还好有备份"
+      tag_list.to_s.should == "我， 东西， 不见了， 还好有备份"
+    end
+  end
+
 end


### PR DESCRIPTION
according to this issue: https://github.com/mbleigh/acts-as-taggable-on/issues/250

I add support for multi delimiters, only add this config:

``` ruby
ActsAsTaggableOn.delimiter = [', ', ' ', '|']
```

add new spec, and all the spec are passed.
