### PR TITLE
Removed deprecation warning

### DIFF
--- a/spec/models.rb
+++ b/spec/models.rb
@@ -35,7 +35,7 @@ class UntaggableModel < ActiveRecord::Base
 end
 
 class NonStandardIdTaggableModel < ActiveRecord::Base
-  set_primary_key "an_id"
+  primary_key = "an_id"
   acts_as_taggable
   acts_as_taggable_on :languages
   acts_as_taggable_on :skills


### PR DESCRIPTION
method 'set_primary_key' has been deprecated. This method call in spec/models.rb raised Deprecation Warning.
