### PR TITLE
#downcase doesn't work on unicode symbols

### DIFF
--- a/lib/acts_as_taggable_on/tag.rb
+++ b/lib/acts_as_taggable_on/tag.rb
@@ -21,7 +21,7 @@ module ActsAsTaggableOn
     end
 
     def self.named_any(list)
-      where(list.map { |tag| sanitize_sql(["lower(name) = ?", tag.to_s.downcase]) }.join(" OR "))
+      where(list.map { |tag| sanitize_sql(["lower(name) = ?", tag.to_s.mb_chars.downcase]) }.join(" OR "))
     end
 
     def self.named_like(name)


### PR DESCRIPTION
After updating this gem, tags functionality was broken on my project
