### PR TITLE
Configuration option to allow for case-sensitive tags

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -228,6 +228,9 @@ If you want tags to be saved parametrized (you can redefine to_param as well):
 
   ActsAsTaggableOn.force_parameterize = true
 
+If you would like tags to be case-sensitive and not use LIKE queries for creation:
+
+  ActsAsTaggableOn.strict_case_match = true
 
 == Contributors
 

--- a/lib/acts-as-taggable-on.rb
+++ b/lib/acts-as-taggable-on.rb
@@ -16,6 +16,9 @@ module ActsAsTaggableOn
   mattr_accessor :force_parameterize
   @@force_parameterize = false
 
+  mattr_accessor :strict_case_match
+  @@strict_case_match = false
+
   mattr_accessor :remove_unused_tags
   self.remove_unused_tags = false
 

--- a/spec/acts_as_taggable_on/tag_spec.rb
+++ b/spec/acts_as_taggable_on/tag_spec.rb
@@ -150,4 +150,33 @@ describe ActsAsTaggableOn::Tag do
 
   end
 
+  describe "when using strict_case_match" do
+    before do
+      ActsAsTaggableOn.strict_case_match = true
+    end
+
+    after do
+      ActsAsTaggableOn.strict_case_match = false
+    end
+
+    it "should find by name" do
+      ActsAsTaggableOn::Tag.find_or_create_with_like_by_name("awesome").should == @tag
+    end
+
+    it "should find by name case sensitively" do
+      tag_count = ActsAsTaggableOn::Tag.count
+      tag       = ActsAsTaggableOn::Tag.find_or_create_with_like_by_name("AWESOME")
+
+      ActsAsTaggableOn::Tag.count.should == tag_count + 1
+      tag.name.should == "AWESOME"
+    end
+
+    it "should have a named_scope named(something) that matches exactly" do
+      uppercase_tag = ActsAsTaggableOn::Tag.create(:name => "Cool")
+      @tag.name     = "cool"
+      @tag.save!
+      ActsAsTaggableOn::Tag.named('cool').should include(@tag)
+      ActsAsTaggableOn::Tag.named('cool').should_not include(uppercase_tag)
+    end
+  end
 end


### PR DESCRIPTION
When the strict_case_match flag is on, LIKE queries are not used to find_or_create tags.
