### PR TITLE
A small fix that prevents error in PostgreSQL

### DIFF
--- a/lib/acts_as_taggable_on/acts_as_taggable_on/collection.rb
+++ b/lib/acts_as_taggable_on/acts_as_taggable_on/collection.rb
@@ -100,8 +100,8 @@ module ActsAsTaggableOn::Taggable
         tag_conditions.each     { |condition| tag_scope     = tag_scope.where(condition)     }
 
         # GROUP BY and HAVING clauses:
-        at_least  = sanitize_sql(['tags_count >= ?', options.delete(:at_least)]) if options[:at_least]
-        at_most   = sanitize_sql(['tags_count <= ?', options.delete(:at_most)]) if options[:at_most]
+        at_least  = sanitize_sql(["COUNT(#{ActsAsTaggableOn::Tagging.table_name}.tag_id) >= ?", options.delete(:at_least)]) if options[:at_least]
+        at_most   = sanitize_sql(["COUNT(#{ActsAsTaggableOn::Tagging.table_name}.tag_id) <= ?", options.delete(:at_most)]) if options[:at_most]
         having    = ["COUNT(#{ActsAsTaggableOn::Tagging.table_name}.tag_id) > 0", at_least, at_most].compact.join(' AND ')    
 
         group_columns = "#{ActsAsTaggableOn::Tagging.table_name}.tag_id"


### PR DESCRIPTION
Postgres throws errors when passing _:at_least_ option to the _tag_counts_on_ method; I traced the execution of these methods and noticed the scope of _tags_count_ in the built SQL sentence; all specs are green and my project is happy again.
