### PR TITLE
customizable classes

### DIFF
--- a/lib/acts_as_taggable_on/tag.rb
+++ b/lib/acts_as_taggable_on/tag.rb
@@ -5,8 +5,10 @@ module ActsAsTaggableOn
     attr_accessible :name
 
     ### ASSOCIATIONS:
-
-    has_many :taggings, :dependent => :destroy, :class_name => 'ActsAsTaggableOn::Tagging'
+    
+    class_attribute :tagging_class
+    self.tagging_class ||= "ActsAsTaggableOn::Tagging"
+    has_many :taggings, :dependent => :destroy, :class_name => tagging_class
 
     ### VALIDATIONS:
 

--- a/lib/acts_as_taggable_on/tagging.rb
+++ b/lib/acts_as_taggable_on/tagging.rb
@@ -10,7 +10,9 @@ module ActsAsTaggableOn
                     :tagger_type,
                     :tagger_id
 
-    belongs_to :tag, :class_name => 'ActsAsTaggableOn::Tag'
+    class_attribute :tag_class
+
+    belongs_to :tag, :class_name => tag_class
     belongs_to :taggable, :polymorphic => true
     belongs_to :tagger,   :polymorphic => true
 

--- a/spec/acts_as_taggable_on/taggable_spec.rb
+++ b/spec/acts_as_taggable_on/taggable_spec.rb
@@ -1,5 +1,81 @@
 require File.expand_path('../../spec_helper', __FILE__)
 
+describe "Applying Taggable Options" do
+  describe "without overriding tag_class and tagging_class" do
+    before :each do
+      clean_database!
+      @taggable = TaggableModel.new
+    end
+    it "should have applied the defaults" do
+      @taggable.class.tagging_class.should == "ActsAsTaggableOn::Tagging"
+      @taggable.class.tag_class.should == "ActsAsTaggableOn::Tag"
+    end
+  end
+
+  describe "customizing the tagging" do
+    before :each do
+      clean_database!
+      @taggable = TaggableModelCustomized.new
+      @taggable.skill_list = ["sewing","cooking"]
+      @taggable.save 
+    end
+
+    describe "specifying the tagging class and tag class" do
+      it "should have the custom classes" do
+        @taggable.class.tagging_class.should == "Tagging"
+        @taggable.class.tag_class.should == "Tag"
+      end
+
+      it "should have informed the tagging class about the tag class" do
+        Tagging.tag_class.should == "Tag"
+      end
+    end
+
+    describe "returning the tags" do
+      
+      it "should have used the right join model" do
+        @taggable.skills.first.taggings.first.should be_a_kind_of(Tagging)
+      end
+
+      it "should always return models from the specified type" do
+        @taggable.skills.first.should be_a_kind_of(Tag)
+      end
+    end
+
+
+  describe "customizing the model that should be returned from the tag lists" do
+    describe "setting the option as a hash" do
+      it "should have the option available " do
+        @taggable.tag_type_options.should == {:groups => "Group"} 
+      end
+    end
+
+    describe "returning the model" do
+      before :each do
+          @taggable.group_list = ["managers","friends"]
+          @taggable.skill_list = ["ruby"]
+          @taggable.save
+      end
+      it "should ownly return models from type group for groups" do
+        @taggable.groups.first.should be_a_kind_of(Group)
+      end
+      it "should still return normal tags for skills" do
+        @taggable.skills.first.should be_a_kind_of(Tag)
+      end
+    end
+
+  end
+
+
+
+  end
+
+
+end
+
+
+
+
 describe "Taggable To Preserve Order" do
   before(:each) do
     clean_database!

--- a/spec/models.rb
+++ b/spec/models.rb
@@ -6,6 +6,29 @@ class TaggableModel < ActiveRecord::Base
   has_many :untaggable_models
 end
 
+
+class Tag < ActsAsTaggableOn::Tag
+end
+
+class Tagging < ActsAsTaggableOn::Tagging
+end
+
+class Group < Tag
+
+end
+
+
+class TaggableModelCustomized < ActiveRecord::Base
+  set_tagging_class "Tagging"
+  set_tag_class "Tag"
+
+  acts_as_taggable
+  acts_as_taggable_on :languages, :skills, :needs, :offerings
+
+  acts_as_taggable_on(:groups => "Group")
+end
+
+
 class CachedModel < ActiveRecord::Base
   acts_as_taggable
 end

--- a/spec/schema.rb
+++ b/spec/schema.rb
@@ -20,6 +20,11 @@ ActiveRecord::Schema.define :version => 0 do
     t.column :name, :string
     t.column :type, :string
   end
+
+  create_table :taggable_model_customizeds, :force => true do |t|
+    t.column :name, :string
+    t.column :type, :string
+ end
   
   create_table :non_standard_id_taggable_models, :primary_key => "an_id", :force => true do |t|
     t.column :name, :string


### PR DESCRIPTION
adding a method to override

a) the Taggings and Tag class in general
b) customize it for single contexts

in order to retreive correct models that can be customized and work with named routes. NOTE the tagger is not covered yet and one test is failing in taggable_spec due to unknown reasons. use reflect_on_all_associations to find it out. NOTE: maybe the whole approach of passing the classes sucks and we have to switch to a global constant. that would work probably just fine

i don't think this should be merged but we should discuss it. we solve substantial problems in a project now with this hack and will have more feedback then.

but general feedback would be highly appreciated.
