### PR TITLE
Create the the index on all four used fields for better performance

### DIFF
--- a/lib/generators/acts_as_taggable_on/migration/templates/active_record/migration.rb
+++ b/lib/generators/acts_as_taggable_on/migration/templates/active_record/migration.rb
@@ -20,7 +20,7 @@ class ActsAsTaggableOnMigration < ActiveRecord::Migration
     end
 
     add_index :taggings, :tag_id
-    add_index :taggings, [:taggable_id, :taggable_type, :context]
+    add_index :taggings, [:taggable_id, :taggable_type, :tag_id, :context], :name => "index_taggings_on_keys"
   end
 
   def self.down


### PR DESCRIPTION
Related to issue #293 - creates the index on all use fields instead of three. This improves the joins tremendously.
