### PR TITLE
avoid instance variable not initialized warnings

### DIFF
--- a/lib/acts_as_taggable_on/acts_as_taggable_on/core.rb
+++ b/lib/acts_as_taggable_on/acts_as_taggable_on/core.rb
@@ -215,12 +215,13 @@ module ActsAsTaggableOn::Taggable
 
       def tag_list_cache_set_on(context)
         variable_name = "@#{context.to_s.singularize}_list"
-        !instance_variable_get(variable_name).nil?
+        instance_variable_defined?(variable_name) && !instance_variable_get(variable_name).nil?
       end
 
       def tag_list_cache_on(context)
         variable_name = "@#{context.to_s.singularize}_list"
-        instance_variable_get(variable_name) || instance_variable_set(variable_name, ActsAsTaggableOn::TagList.new(tags_on(context).map(&:name)))
+        return instance_variable_get(variable_name) if instance_variable_defined?(variable_name) && instance_variable_get(variable_name)
+        instance_variable_set(variable_name, ActsAsTaggableOn::TagList.new(tags_on(context).map(&:name)))
       end
 
       def tag_list_on(context)
@@ -230,7 +231,7 @@ module ActsAsTaggableOn::Taggable
 
       def all_tags_list_on(context)
         variable_name = "@all_#{context.to_s.singularize}_list"
-        return instance_variable_get(variable_name) if instance_variable_get(variable_name)
+        return instance_variable_get(variable_name) if instance_variable_defined?(variable_name) && instance_variable_get(variable_name)
 
         instance_variable_set(variable_name, ActsAsTaggableOn::TagList.new(all_tags_on(context).map(&:name)).freeze)
       end

--- a/lib/acts_as_taggable_on/acts_as_taggable_on/ownership.rb
+++ b/lib/acts_as_taggable_on/acts_as_taggable_on/ownership.rb
@@ -45,7 +45,7 @@ module ActsAsTaggableOn::Taggable
 
       def cached_owned_tag_list_on(context)
         variable_name = "@owned_#{context}_list"
-        cache = instance_variable_get(variable_name) || instance_variable_set(variable_name, {})
+        cache = (instance_variable_defined?(variable_name) && instance_variable_get(variable_name)) || instance_variable_set(variable_name, {})
       end
       
       def owner_tag_list_on(owner, context)


### PR DESCRIPTION
Hello, in running tests on my app using ruby's verbose mode, I noticed acts-as-taggable-on was throwing a few uninitialized variable warnings.

I don't think there's anything too controversial here but I'm happy to make tweaks if needed.

Thanks for the library, it is very useful.
