### PR TITLE
Implemented find_related_tags(:ignore => ['foo', 'bar'])

### DIFF
--- a/lib/acts_as_taggable_on/acts_as_taggable_on/related.rb
+++ b/lib/acts_as_taggable_on/acts_as_taggable_on/related.rb
@@ -56,7 +56,9 @@ module ActsAsTaggableOn::Taggable
       end
 
       def related_tags_for(context, klass, options = {})
-        tags_to_find = tags_on(context).collect { |t| t.name }
+				tags_to_ignore = Array.wrap(options.delete(:ignore)) || []
+				tags_to_ignore.map! { |t| t.to_s }
+        tags_to_find = tags_on(context).collect { |t| t.name }.reject { |t| tags_to_ignore.include? t }
 
         exclude_self = "#{klass.table_name}.#{klass.primary_key} != #{id} AND" if [self.class.base_class, self.class].include? klass
 

--- a/spec/acts_as_taggable_on/acts_as_taggable_on_spec.rb
+++ b/spec/acts_as_taggable_on/acts_as_taggable_on_spec.rb
@@ -185,6 +185,39 @@ describe "Acts As Taggable On" do
       taggable1.find_related_tags.should_not include(taggable1)
     end
 
+		context "Ignored Tags" do
+			let(:taggable1) { TaggableModel.create!(:name => "Taggable 1") }
+			let(:taggable2) { TaggableModel.create!(:name => "Taggable 2") }
+			let(:taggable3) { TaggableModel.create!(:name => "Taggable 3") }
+			before(:each) do
+				taggable1.tag_list = "one, two, four"
+				taggable1.save
+
+				taggable2.tag_list = "two, three"
+				taggable2.save
+
+				taggable3.tag_list = "one, three"
+				taggable3.save
+			end
+			it "should not include ignored tags in related search" do
+				taggable1.find_related_tags(:ignore => 'two').should_not include(taggable2)
+				taggable1.find_related_tags(:ignore => 'two').should include(taggable3)
+			end
+
+			it "should accept array of ignored tags" do
+				taggable4 = TaggableModel.create!(:name => "Taggable 4")
+				taggable4.tag_list = "four"
+				taggable4.save
+
+				taggable1.find_related_tags(:ignore => ['two', 'four']).should_not include(taggable2)
+				taggable1.find_related_tags(:ignore => ['two', 'four']).should_not include(taggable4)
+			end
+
+			it "should accept symbols as ignored tags" do
+				taggable1.find_related_tags(:ignore => :two).should_not include(taggable2)
+			end
+		end
+
     context "Inherited Models" do
       before do
         @taggable1 = InheritingTaggableModel.create!(:name => "InheritingTaggable 1")


### PR DESCRIPTION
Hi,
At times I need to explicitly exclude a tag from the related_tags search to improve the result-quality (think of tags that are very common but skew the results in unforseen ways).

So I decided to implement this as a special key in the options of `related_tags_for called` `:ignore`.
I included some tests, please let me know if I did something insanely stupid :)

Works with single values, symbols and arrays of values/symbols.
