### PR TITLE
Improve performance of all_tag_counts on large tables.

### DIFF
--- a/lib/acts_as_taggable_on/acts_as_taggable_on/collection.rb
+++ b/lib/acts_as_taggable_on/acts_as_taggable_on/collection.rb
@@ -167,8 +167,9 @@ module ActsAsTaggableOn::Taggable
         select_query = "#{select(scoped_select).to_sql}"
 
         res = ActiveRecord::Base.connection.select_all(select_query).map { |item| item.values }.flatten.join(",")
+        res = "NULL" if res.blank?
 
-        tagging_scope = tagging_scope.where("#{ActsAsTaggableOn::Tagging.table_name}.taggable_id IN(#{res})") if res.present?
+        tagging_scope = tagging_scope.where("#{ActsAsTaggableOn::Tagging.table_name}.taggable_id IN(#{res})")
         tagging_scope = tagging_scope.group(group_columns).having(having)
 
         tag_scope = tag_scope.joins("JOIN (#{tagging_scope.to_sql}) AS #{ActsAsTaggableOn::Tagging.table_name} ON #{ActsAsTaggableOn::Tagging.table_name}.tag_id = #{ActsAsTaggableOn::Tag.table_name}.id")


### PR DESCRIPTION
Refactored the sub select to actually do a separate query. This improves the performance of the count methods drastically for MySQL/SQLite. I was unable to test this under the pg driver, however that should work fine.

All tests are passing on my side, and I had a 100+ second query drop to 2 seconds on my production server. Let me know if there is anything else you need.

If there are any regressions that you see, let me know and I can refactor this until it is performant and works perfectly for everyone.

Thanks again for a great lib.
