### PR TITLE
only use attr_accessible if it's supported

### DIFF
--- a/lib/acts_as_taggable_on/tag.rb
+++ b/lib/acts_as_taggable_on/tag.rb
@@ -2,7 +2,7 @@ module ActsAsTaggableOn
   class Tag < ::ActiveRecord::Base
     include ActsAsTaggableOn::Utils
 
-    attr_accessible :name
+    attr_accessible :name if defined?(ActiveModel::MassAssignmentSecurity)
 
     ### ASSOCIATIONS:
 

--- a/lib/acts_as_taggable_on/tagging.rb
+++ b/lib/acts_as_taggable_on/tagging.rb
@@ -8,7 +8,7 @@ module ActsAsTaggableOn
                     :taggable_id,
                     :tagger,
                     :tagger_type,
-                    :tagger_id
+                    :tagger_id if defined?(ActiveModel::MassAssignmentSecurity)
 
     belongs_to :tag, :class_name => 'ActsAsTaggableOn::Tag'
     belongs_to :taggable, :polymorphic => true


### PR DESCRIPTION
Rails 4 doesn't define the ActiveModel::MassAssignmentSecurity constant, but
there is a gem that allows it to be used. The models will now only try to use
the functionality if the constant is defined

fixes #334
