### PR TITLE
Use of these methods is preferred for Rails 4

### DIFF
--- a/lib/acts_as_taggable_on/acts_as_taggable_on/core.rb
+++ b/lib/acts_as_taggable_on/acts_as_taggable_on/core.rb
@@ -275,7 +275,7 @@ module ActsAsTaggableOn::Taggable
         # when preserving tag order, return tags in created order
         # if we added the order to the association this would always apply
         scope = scope.order("#{ActsAsTaggableOn::Tagging.table_name}.id") if self.class.preserve_tag_order?
-        scope.all
+        scope.to_a
       end
 
       def set_tag_list_on(context, new_list)

--- a/lib/acts_as_taggable_on/tag.rb
+++ b/lib/acts_as_taggable_on/tag.rb
@@ -60,7 +60,7 @@ module ActsAsTaggableOn
 
       return [] if list.empty?
 
-      existing_tags = Tag.named_any(list).all
+      existing_tags = Tag.named_any(list)
       new_tag_names = list.reject do |name|
         name = comparable_name(name)
         existing_tags.any? { |tag| comparable_name(tag.name) == name }


### PR DESCRIPTION
The Relation#all method is deprecated as of Rails 4, we should use these to
acheive the desired behavior.
