### PR TITLE
Force alphanumerical characters. Callback for temporary solution with unexpected appearance of quotes in tagnames.

### DIFF
--- a/lib/acts-as-taggable-on.rb
+++ b/lib/acts-as-taggable-on.rb
@@ -16,6 +16,9 @@ module ActsAsTaggableOn
   mattr_accessor :force_parameterize
   @@force_parameterize = false
 
+  mattr_accessor :force_alphanumeric
+  @@force_alphanumeric = false
+
   mattr_accessor :strict_case_match
   @@strict_case_match = false
 

--- a/lib/acts_as_taggable_on/tag.rb
+++ b/lib/acts_as_taggable_on/tag.rb
@@ -14,6 +14,9 @@ module ActsAsTaggableOn
     validates_uniqueness_of :name, :if => :validates_name_uniqueness?
     validates_length_of :name, :maximum => 255
 
+    ### CALLBACKS:
+    after_save :clean_quotes_magic
+
     # monkey patch this method if don't need name uniqueness validation
     def validates_name_uniqueness?
       true
@@ -95,5 +98,14 @@ module ActsAsTaggableOn
         /mysql/ === ActiveRecord::Base.connection_config[:adapter] ? "BINARY " : nil
       end
     end
+
+    private
+      def clean_quotes_magic
+        if name =~ /^\\?'/
+          self.update_attributes(
+            name: name.gsub(/[\\']/, '')
+          )
+        end
+      end
   end
 end

--- a/lib/acts_as_taggable_on/tag_list.rb
+++ b/lib/acts_as_taggable_on/tag_list.rb
@@ -81,6 +81,7 @@ module ActsAsTaggableOn
     def clean!
       reject!(&:blank?)
       map!(&:strip)
+      map!{ |tag| tag.mb_chars.gsub!(/[^[:alnum:] ]+/, '') } if ActsAsTaggableOn.force_alphanumeric
       map!{ |tag| tag.mb_chars.downcase.to_s } if ActsAsTaggableOn.force_lowercase
       map!(&:parameterize) if ActsAsTaggableOn.force_parameterize
 


### PR DESCRIPTION
- Force_parameterize not fit for case with non-latin charsets, because it transliterate text to latin. Suggest to use force_alphanumerical for non-latin charsets.
- I suggest to check if name contains ' or \' and update it immediately by callback. Maybe as temporary solution of issue #345.
