### PR TITLE
Optimize acts_as_ordered_taggable

### DIFF
--- a/lib/acts_as_taggable_on/acts_as_taggable_on/core.rb
+++ b/lib/acts_as_taggable_on/acts_as_taggable_on/core.rb
@@ -337,13 +337,20 @@ module ActsAsTaggableOn::Taggable
 
           # Tag maintenance based on whether preserving the created order of tags
           if self.class.preserve_tag_order?
-            # First off order the array of tag objects to match the tag list
-            # rather than existing tags followed by new tags
-            tags = tag_list.map{|l| tags.detect{|t| t.name.downcase == l.downcase}}
-            # To preserve tags in the order in which they were added
-            # delete all current tags and create new tags if the content or order has changed
-            old_tags = (tags == current_tags ? [] : current_tags)
-            new_tags = (tags == current_tags ? [] : tags)
+            old_tags, new_tags = current_tags - tags, tags - current_tags
+
+            shared_tags = current_tags & tags
+
+            if shared_tags.any? && tags[0...shared_tags.size] != shared_tags
+              index = shared_tags.each_with_index { |_, i| break i unless shared_tags[i] == tags[i] }
+
+              # Update arrays of tag objects
+              old_tags |= current_tags.from(index)
+              new_tags |= current_tags.from(index) & shared_tags
+
+              # Order the array of tag objects to match the tag list
+              new_tags = tags.map { |t| new_tags.find { |n| n.name.downcase == t.name.downcase } }.compact
+            end
           else
             # Delete discarded tags and create new tags
             old_tags = current_tags - tags

--- a/lib/acts_as_taggable_on/tag.rb
+++ b/lib/acts_as_taggable_on/tag.rb
@@ -61,13 +61,13 @@ module ActsAsTaggableOn
       return [] if list.empty?
 
       existing_tags = Tag.named_any(list)
-      new_tag_names = list.reject do |name|
-        name = comparable_name(name)
-        existing_tags.any? { |tag| comparable_name(tag.name) == name }
-      end
-      created_tags  = new_tag_names.map { |name| Tag.create(:name => name) }
 
-      existing_tags + created_tags
+      list.map do |tag_name|
+        comparable_tag_name = comparable_name(tag_name)
+        existing_tag = existing_tags.find { |tag| comparable_name(tag.name) == comparable_tag_name }
+
+        existing_tag || Tag.create(:name => tag_name)
+      end
     end
 
     ### INSTANCE METHODS:


### PR DESCRIPTION
Hi there,

I wanted to propose optimization for acts_as_ordered_taggable. It has very wrong behavior.

I've created a simple [gist](https://gist.github.com/rsamoilov/5419220) - when I want to add the tag to my object, logic behind acts_as_ordered_taggable recreates from scratch all taggings. I just wanted to perform such simple operation as adding a tag, but got monstrous sql queries instead.

Initial tags order is being violated in `Tag#find_or_create_all_with_like_by_name`. I've created fix for this method to preserve tags order.
Also, I added fix to `save_tags` methods. It looks pretty complex, but it's the simplest working version I've come up with.

Actually, I believe, that preserving tags order should be the default and only one possible behavior. So, maybe it makes sense to remove acts_as_ordered_taggable at all and move this optimization to acts_as_ordered. 
