### PR TITLE
Saving comma separated tags is incorrect

### DIFF
--- a/spec/acts_as_taggable_on/taggable_spec.rb
+++ b/spec/acts_as_taggable_on/taggable_spec.rb
@@ -519,6 +519,13 @@ describe "Taggable" do
       @taggable.reload
       @taggable.tag_list_on(:test).should == ["hello"]
     end
+
+    it "should be able to create tags containing a comma" do
+      @taggable.skill_list = ["Watfiv, watfor",'hello']
+      @taggable.save
+      @taggable.reload
+      @taggable.skill_list.should == ['Watfiv, watfor', 'hello']
+    end
   end
 
   describe "Dirty Objects" do


### PR DESCRIPTION
Here's a mystery. I tried adding "WATFIV, WATFOR" as a tag, but it gets saved as WATFIV and WATFOR separately, even though tag_list correctly parses the string into 1 tag.

```
irb(main):079:0> jure.knowledge_list ='"WATFIV, WATFOR", hello'
=> "\"WATFIV, WATFOR\", hello"
irb(main):080:0> jure.knowledge_list
=> ["WATFIV, WATFOR", "hello"]
irb(main):081:0> jure.knowledge_list.size
=> 2
irb(main):082:0> jure.save
   (0.4ms)  BEGIN
  User Exists (0.6ms)  SELECT 1 AS one FROM "users" WHERE ("users"."name" = 'jure' AND "users"."id" != 2) LIMIT 1
   (0.6ms)  UPDATE "users" SET "updated_at" = '2012-10-16 11:28:14.610106' WHERE "users"."id" = 2
  ActsAsTaggableOn::Tag Load (5.8ms)  SELECT "tags".* FROM "tags" WHERE (lower(name) = 'watfiv' OR lower(name) = 'watfor' OR lower(name) = 'hello')
  ActsAsTaggableOn::Tag Load (0.7ms)  SELECT "tags".* FROM "tags" INNER JOIN "taggings" ON "tags"."id" = "taggings"."tag_id" WHERE "taggings"."taggable_id" = 2 AND "taggings"."taggable_type" = 'User' AND (taggings.context = 'knowledge' AND taggings.tagger_id IS NULL)
  ActsAsTaggableOn::Tagging Exists (0.5ms)  SELECT 1 AS one FROM "taggings" WHERE ("taggings"."tag_id" = 1977 AND "taggings"."taggable_type" = 'User' AND "taggings"."taggable_id" = 2 AND "taggings"."context" = 'knowledge' AND "taggings"."tagger_id" IS NULL AND "taggings"."tagger_type" IS NULL) LIMIT 1
  SQL (0.5ms)  INSERT INTO "taggings" ("context", "created_at", "tag_id", "taggable_id", "taggable_type", "tagger_id", "tagger_type") VALUES ($1, $2, $3, $4, $5, $6, $7) RETURNING "id"  [["context", "knowledge"], ["created_at", Tue, 16 Oct 2012 11:28:14 UTC +00:00], ["tag_id", 1977], ["taggable_id", 2], ["taggable_type", "User"], ["tagger_id", nil], ["tagger_type", nil]]
  ActsAsTaggableOn::Tagging Exists (0.5ms)  SELECT 1 AS one FROM "taggings" WHERE ("taggings"."tag_id" = 1978 AND "taggings"."taggable_type" = 'User' AND "taggings"."taggable_id" = 2 AND "taggings"."context" = 'knowledge' AND "taggings"."tagger_id" IS NULL AND "taggings"."tagger_type" IS NULL) LIMIT 1
  SQL (0.4ms)  INSERT INTO "taggings" ("context", "created_at", "tag_id", "taggable_id", "taggable_type", "tagger_id", "tagger_type") VALUES ($1, $2, $3, $4, $5, $6, $7) RETURNING "id"  [["context", "knowledge"], ["created_at", Tue, 16 Oct 2012 11:28:14 UTC +00:00], ["tag_id", 1978], ["taggable_id", 2], ["taggable_type", "User"], ["tagger_id", nil], ["tagger_type", nil]]
  ActsAsTaggableOn::Tagging Exists (0.5ms)  SELECT 1 AS one FROM "taggings" WHERE ("taggings"."tag_id" = 1979 AND "taggings"."taggable_type" = 'User' AND "taggings"."taggable_id" = 2 AND "taggings"."context" = 'knowledge' AND "taggings"."tagger_id" IS NULL AND "taggings"."tagger_type" IS NULL) LIMIT 1
  SQL (0.4ms)  INSERT INTO "taggings" ("context", "created_at", "tag_id", "taggable_id", "taggable_type", "tagger_id", "tagger_type") VALUES ($1, $2, $3, $4, $5, $6, $7) RETURNING "id"  [["context", "knowledge"], ["created_at", Tue, 16 Oct 2012 11:28:14 UTC +00:00], ["tag_id", 1979], ["taggable_id", 2], ["taggable_type", "User"], ["tagger_id", nil], ["tagger_type", nil]]
  ActsAsTaggableOn::Tag Load (0.7ms)  SELECT "tags".* FROM "tags" INNER JOIN "taggings" ON "tags"."id" = "taggings"."tag_id" WHERE "taggings"."taggable_id" = 2 AND "taggings"."taggable_type" = 'User' AND (taggings.context = 'interests' AND taggings.tagger_id IS NULL)
   (0.6ms)  COMMIT
=> true
irb(main):083:0> jure.reload
  User Load (1.5ms)  SELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT 1  [["id", 2]]
=> #<User id: 2, email: "FILTERED", encrypted_password: "FILTERED", reset_password_token: nil, reset_password_sent_at: nil, remember_created_at: nil, sign_in_count: 2, current_sign_in_at: "2012-10-15 00:48:02", last_sign_in_at: "2012-10-14 23:54:19", current_sign_in_ip: "193.77.90.229", last_sign_in_ip: "FILTERED", created_at: "2012-10-14 23:54:19", updated_at: "2012-10-16 11:28:14", name: "jure">
irb(main):084:0> jure.knowledge_list
  ActsAsTaggableOn::Tag Load (1.2ms)  SELECT "tags".* FROM "tags" INNER JOIN "taggings" ON "tags"."id" = "taggings"."tag_id" WHERE "taggings"."taggable_id" = 2 AND "taggings"."taggable_type" = 'User' AND (taggings.context = 'knowledge' AND taggings.tagger_id IS NULL)
=> ["Watfiv", "watfor", "Hello"]
irb(main):085:0> jure.knowledge_list.size
=> 3
```

So even though the knowledge_list reader correctly parses the tags, the .save calls something else that parses the string incorrectly and splits the tags on that comma. Any ideas? I'll dig a bit deeper myself.
