### PR TITLE
Refactored to go back to sub selects

### DIFF
--- a/lib/acts_as_taggable_on/acts_as_taggable_on/collection.rb
+++ b/lib/acts_as_taggable_on/acts_as_taggable_on/collection.rb
@@ -87,12 +87,7 @@ module ActsAsTaggableOn::Taggable
 
         # Append the current scope to the scope, because we can't use scope(:find) in RoR 3.0 anymore:
         scoped_select = "#{table_name}.#{primary_key}"
-        select_query = "#{select(scoped_select).to_sql}"
-
-        res = ActiveRecord::Base.connection.select_all(select_query).map { |item| item.values }.flatten.join(",")
-        res = "NULL" if res.blank?
-
-        tagging_scope = tagging_scope.where("#{ActsAsTaggableOn::Tagging.table_name}.taggable_id IN(#{res})").group(group_columns)
+        tagging_scope = tagging_scope.where("#{ActsAsTaggableOn::Tagging.table_name}.taggable_id IN(#{select(scoped_select).to_sql})").group(group_columns)
 
         tag_scope = tag_scope.joins("JOIN (#{tagging_scope.to_sql}) AS #{ActsAsTaggableOn::Tagging.table_name} ON #{ActsAsTaggableOn::Tagging.table_name}.tag_id = #{ActsAsTaggableOn::Tag.table_name}.id")
         tag_scope
@@ -166,15 +161,10 @@ module ActsAsTaggableOn::Taggable
 
         group_columns = "#{ActsAsTaggableOn::Tagging.table_name}.tag_id"
 
-        # Append the current scope to the scope, because we can't use scope(:find) in RoR 3.0 anymore:
         unless options[:id]
+          # Append the current scope to the scope, because we can't use scope(:find) in RoR 3.0 anymore:
           scoped_select = "#{table_name}.#{primary_key}"
-          select_query = "#{select(scoped_select).to_sql}"
-
-          res = ActiveRecord::Base.connection.select_all(select_query).map { |item| item.values }.flatten.join(",")
-          res = "NULL" if res.blank?
-
-          tagging_scope = tagging_scope.where("#{ActsAsTaggableOn::Tagging.table_name}.taggable_id IN(#{res})")
+          tagging_scope = tagging_scope.where("#{ActsAsTaggableOn::Tagging.table_name}.taggable_id IN(#{select(scoped_select).to_sql})")
         end
 
         tagging_scope = tagging_scope.group(group_columns).having(having)


### PR DESCRIPTION
This switches back to sub selects, and also has an optimization where it doesn't do the sub select if it already knows the exact object id.
