### PR TITLE
fix a spelling error in spec_helper

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,7 +14,7 @@ begin
   Bundler.setup
 rescue Bundler::GemNotFound
   raise RuntimeError, "Bundler couldn't find some gems." +
-    "Did you run \`bundlee install\`?"
+    "Did you run \`bundle install\`?"
 end
 
 Bundler.require


### PR DESCRIPTION
This is a really trivial change. A spelling error was introduced in 25db402c3397059f3762c356f3069049ed7b6b02. This pull request fixes it.
