### PR TITLE
Only chain #having to tagged_with query when clause is present.

### DIFF
--- a/lib/acts_as_taggable_on/acts_as_taggable_on/core.rb
+++ b/lib/acts_as_taggable_on/acts_as_taggable_on/core.rb
@@ -191,13 +191,13 @@ module ActsAsTaggableOn::Taggable
           having = "COUNT(#{taggings_alias}.taggable_id) = #{tags.size}"
         end
 
-        select(select_clause) \
+        query = select(select_clause) \
           .joins(joins.join(" ")) \
           .where(conditions.join(" AND ")) \
           .group(group) \
-          .having(having) \
           .order(options[:order]) \
           .readonly(false)
+        having.blank? ? query : query.having(having)
       end
 
       def is_taggable?


### PR DESCRIPTION
This fixes issue #365 in Rails 3.0.20 by omitting the `having` part of the query when it is not present.
