### PR TITLE
load attribute_accessors for ActiveSupport 4

### DIFF
--- a/lib/acts-as-taggable-on.rb
+++ b/lib/acts-as-taggable-on.rb
@@ -1,6 +1,7 @@
 require "active_record"
 require "active_record/version"
 require "action_view"
+require 'active_support/core_ext/module/attribute_accessors'
 
 require "digest/sha1"
 


### PR DESCRIPTION
When using ActiveSupport 4, we must explicitly load attribute_accessors in order to use the mattr_accessor function in the ActsAsTaggableOn module.

Tested with ActiveSupport 4.0.0.
