### PR TITLE
Check to see if we can connect to the db before accessing it. Fixes #396.

### DIFF
--- a/lib/acts_as_taggable_on/acts_as_taggable_on/cache.rb
+++ b/lib/acts_as_taggable_on/acts_as_taggable_on/cache.rb
@@ -2,7 +2,7 @@ module ActsAsTaggableOn::Taggable
   module Cache
     def self.included(base)
       # Skip adding caching capabilities if table not exists or no cache columns exist
-      return unless base.table_exists? && base.tag_types.any? { |context| base.column_names.include?("cached_#{context.to_s.singularize}_list") }
+      return unless base.connected? && base.table_exists? && base.tag_types.any? { |context| base.column_names.include?("cached_#{context.to_s.singularize}_list") }
 
       base.send :include, ActsAsTaggableOn::Taggable::Cache::InstanceMethods
       base.extend ActsAsTaggableOn::Taggable::Cache::ClassMethods


### PR DESCRIPTION
Fix heroku precompile assets breaking with Rails 4. Fixes #396.

This fails specs for unrelated reasons that have been addressed in #404. I have been able to deploy to Heroku with an app running Rails 4 using this fork. It should be good to merge.
