### PR TITLE
Fix missing mattr_accessor require, README test info

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ directory, you can run the specs with:
 
 ```shell
 bundle
+cp spec/database.yml{.sample,}
 rake spec
 ```
 

--- a/lib/acts-as-taggable-on.rb
+++ b/lib/acts-as-taggable-on.rb
@@ -1,5 +1,6 @@
 require "active_record"
 require "active_record/version"
+require "active_support/core_ext/module"
 require "action_view"
 require 'active_support/all'
 


### PR DESCRIPTION
Needed two extra steps to get test instructions running out of the box :smile: 
