### PR TITLE
Let '.count' work when tagged_with is accompanied by a group clause

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ As such, a _Feature_ would map to either major or minor. A _bug fix_ to a patch.
   * [@rafael #406 Dirty attributes not correctly derived](https://github.com/mbleigh/acts-as-taggable-on/pull/406)
   * [@bzbnhang #440 Did not respect strict_case_match](https://github.com/mbleigh/acts-as-taggable-on/pull/440)
   * [@znz #456 Fix breaking encoding of tag](https://github.com/mbleigh/acts-as-taggable-on/pull/456)
+  * [@rgould #417 Let '.count' work when tagged_with is accompanied by a group clause](https://github.com/mbleigh/acts-as-taggable-on/pull/417)
 * Misc
   * [@billychan #463 Thread safe support](https://github.com/mbleigh/acts-as-taggable-on/pull/463)
   * [@billychan #386 Add parse:true instructions to README](https://github.com/mbleigh/acts-as-taggable-on/pull/386)

--- a/lib/acts_as_taggable_on/acts_as_taggable_on/core.rb
+++ b/lib/acts_as_taggable_on/acts_as_taggable_on/core.rb
@@ -180,6 +180,7 @@ module ActsAsTaggableOn::Taggable
           end
         end
 
+        group = [] # Rails interprets this as a no-op in the group() call below
         if options.delete(:order_by_matching_tag_count)
           select_clause = "#{table_name}.*, COUNT(#{taggings_alias}.tag_id) AS #{taggings_alias}_count"
           group_columns = ActsAsTaggableOn::Tag.using_postgresql? ? grouped_column_names_for(self) : "#{table_name}.#{primary_key}"

--- a/spec/acts_as_taggable_on/taggable_spec.rb
+++ b/spec/acts_as_taggable_on/taggable_spec.rb
@@ -216,6 +216,13 @@ describe "Taggable" do
     TaggableModel.tagged_with("ruby").first.should == @taggable
   end
 
+  it "should be able to get a count with find by tag when using a group by" do
+    @taggable.skill_list = "ruby"
+    @taggable.save
+
+    expect(TaggableModel.tagged_with("ruby").group(:created_at).count.count).to eq(1)
+  end
+
   it "should be able to find by tag with context" do
     @taggable.skill_list = "ruby, rails, css"
     @taggable.tag_list = "bob, charlie"


### PR DESCRIPTION
Give `group` a default of `[]`, which will later evaluate into a no-op by Rails. Previously this would be `nil`, which Rails translates to " AS " in SQL, generating an invalid statement.
