### PR TITLE
Add Code Climate badge to repo README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # ActsAsTaggableOn
 [![Build Status](https://secure.travis-ci.org/mbleigh/acts-as-taggable-on.png)](http://travis-ci.org/mbleigh/acts-as-taggable-on)
+[![Code Climate](https://codeclimate.com/github/mbleigh/acts-as-taggable-on.png)](https://codeclimate.com/github/mbleigh/acts-as-taggable-on)
 
 This plugin was originally based on Acts as Taggable on Steroids by Jonathan Viney.
 It has evolved substantially since that point, but all credit goes to him for the


### PR DESCRIPTION
Hello!

Today when I was poking around some of the Open Source repos on Code Climate, I noticed `acts-as-taggable-on` was present but didn't have a badge on its README. Code Climate is a tool I helped to build that does automated code reviews for Ruby using static analysis. It's free for OSS, and your metrics live here:

https://codeclimate.com/github/mbleigh/acts-as-taggable-on

This PR just adds a dynamic badge to the README (similar to Travis) that displays the code quality GPA, in case you want this information to be available to contributors.

If you have any questions, let me know.

I hope you find Code Climate useful.

Cheers,
