### PR TITLE
Move cache table existence check in method

### DIFF
--- a/lib/acts_as_taggable_on/acts_as_taggable_on/cache.rb
+++ b/lib/acts_as_taggable_on/acts_as_taggable_on/cache.rb
@@ -1,41 +1,38 @@
 module ActsAsTaggableOn::Taggable
   module Cache
     def self.included(base)
-      # Skip adding caching capabilities if table not exists or no cache columns exist
-      return unless base.table_exists? && base.tag_types.any? { |context| base.column_names.include?("cached_#{context.to_s.singularize}_list") }
-
       base.send :include, ActsAsTaggableOn::Taggable::Cache::InstanceMethods
       base.extend ActsAsTaggableOn::Taggable::Cache::ClassMethods
-      
+
       base.class_eval do
-        before_save :save_cached_tag_list        
+        before_save :save_cached_tag_list
       end
-      
+
       base.initialize_acts_as_taggable_on_cache
     end
-    
+
     module ClassMethods
-      def initialize_acts_as_taggable_on_cache      
+      def initialize_acts_as_taggable_on_cache
         tag_types.map(&:to_s).each do |tag_type|
           class_eval <<-RUBY, __FILE__, __LINE__ + 1
             def self.caching_#{tag_type.singularize}_list?
               caching_tag_list_on?("#{tag_type}")
-            end        
+            end
           RUBY
-        end        
+        end
       end
-      
+
       def acts_as_taggable_on(*args)
         super(*args)
         initialize_acts_as_taggable_on_cache
       end
-      
+
       def caching_tag_list_on?(context)
-        column_names.include?("cached_#{context.to_s.singularize}_list")
+        table_exists? && column_names.include?("cached_#{context.to_s.singularize}_list")
       end
     end
-    
-    module InstanceMethods      
+
+    module InstanceMethods
       def save_cached_tag_list
         tag_types.map(&:to_s).each do |tag_type|
           if self.class.send("caching_#{tag_type.singularize}_list?")
@@ -45,7 +42,7 @@ module ActsAsTaggableOn::Taggable
             end
           end
         end
-        
+
         true
       end
     end


### PR DESCRIPTION
It used to require a database connection during assets:precompile, which prevents deployment to Heroku
