### PR TITLE
Use String#b if available

### DIFF
--- a/lib/acts_as_taggable_on/tag.rb
+++ b/lib/acts_as_taggable_on/tag.rb
@@ -108,10 +108,14 @@ module ActsAsTaggableOn
       end
 
       def as_8bit_ascii(string)
-        if defined?(Encoding)
-          string.to_s.force_encoding('BINARY')
+        string = string.to_s
+        if string.respond_to?(:b)
+          # ruby >= 2.0.0 has String#b.
+          string.b
+        elsif defined?(Encoding)
+          string.force_encoding('BINARY')
         else
-          string.to_s.mb_chars
+          string.mb_chars
         end
       end
     end


### PR DESCRIPTION
ruby 2.1 introduces Frozen String optimization and "literal".to_s.force_encoding('BINARY') will raise RuntimeError saying "can't modify frozen String".
See http://bugs.ruby-lang.org/issues/8992 .

We should use String#b introduced in ruby 2.0.0.
