### PR TITLE
Remove I18n Deprecation warning in tests.

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,6 +3,7 @@ $LOAD_PATH.unshift(File.expand_path('../../lib', __FILE__))
 require 'logger'
 
 require File.expand_path('../../lib/acts-as-taggable-on', __FILE__)
+I18n.enforce_available_locales = true
 require 'ammeter/init'
 
 unless [].respond_to?(:freq)


### PR DESCRIPTION
This patch remove this annoying message : 
   [deprecated] I18n.enforce_available_locales will default to true in the future. If you really want to skip validation of your locale you can set I18n.enforce_available_locales = false to avoid this message.
