### PR TITLE
tests: fix ammeter with Rails 4

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,7 +4,7 @@ require 'logger'
 
 require File.expand_path('../../lib/acts-as-taggable-on', __FILE__)
 I18n.enforce_available_locales = true
-require 'ammeter/init'
+require 'ammeter'
 
 unless [].respond_to?(:freq)
   class Array


### PR DESCRIPTION
Ammeter needs to load rails before loading ammeter/init. If spec_helper loads ammeter/init before rails, this leads to a NameError crash (with Rails 4).

The way to avoid this is to load "`ammeter`" instead of "`ammeter/init`".

See https://bugzilla.redhat.com/1007631 for more information.

I'm not 100% sure that this works on Rails 3, but I've tested with Rails 4 and it allows `rspec -Ilib spec` to pass.
