### PR TITLE
Move 'Distinct' out of select string and use .uniq instead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ As such, a _Feature_ would map to either major or minor. A _bug fix_ to a patch.
   * [@bzbnhang #440 Did not respect strict_case_match](https://github.com/mbleigh/acts-as-taggable-on/pull/440)
   * [@znz #456 Fix breaking encoding of tag](https://github.com/mbleigh/acts-as-taggable-on/pull/456)
   * [@rgould #417 Let '.count' work when tagged_with is accompanied by a group clause](https://github.com/mbleigh/acts-as-taggable-on/pull/417)
+  * [@developer88 #461 Move 'Distinct' out of select string and use .uniq instead](https://github.com/mbleigh/acts-as-taggable-on/pull/461)
 * Misc
   * [@billychan #463 Thread safe support](https://github.com/mbleigh/acts-as-taggable-on/pull/463)
   * [@billychan #386 Add parse:true instructions to README](https://github.com/mbleigh/acts-as-taggable-on/pull/386)


### PR DESCRIPTION
Fix issue https://github.com/mbleigh/acts-as-taggable-on/issues/357 

When using :any => true option in tagged_with method along with other ActiveRecord query get and error like: 

"PG::Error: ERROR: syntax error at or near "DISTINCT"

So i move 'Distinct' out to the end of tagged_with method definition and use .uniq method instead.
