### PR TITLE
See #467, add option to order by number of matching tags.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ As such, a _Feature_ would map to either major or minor. A _bug fix_ to a patch.
 
 * Breaking Changes
 * Features
+  * [@jamesburke-examtime #467 Add :order_by_matching_tag_count option](https://github.com/mbleigh/acts-as-taggable-on/pull/469)
 * Fixes
   * [@rafael #406 Dirty attributes not correctly derived](https://github.com/mbleigh/acts-as-taggable-on/pull/406)
   * [@bzbnhang #440 Did not respect strict_case_match](https://github.com/mbleigh/acts-as-taggable-on/pull/440)

--- a/spec/acts_as_taggable_on/taggable_spec.rb
+++ b/spec/acts_as_taggable_on/taggable_spec.rb
@@ -369,6 +369,18 @@ describe "Taggable" do
     TaggableModel.tagged_with(["depressed", "css"], :order => 'taggable_models.name', :any => true).to_a.should == [bob, frank]
   end
 
+  it "should be able to order by number of matching tags when matching any" do
+    bob = TaggableModel.create(:name => "Bob", :tag_list => "fitter, happier, more productive", :skill_list => "ruby, rails, css")
+    frank = TaggableModel.create(:name => "Frank", :tag_list => "weaker, depressed, inefficient", :skill_list => "ruby, rails, css")
+    steve = TaggableModel.create(:name => 'Steve', :tag_list => 'fitter, happier, more productive', :skill_list => 'c++, java, ruby')
+
+    TaggableModel.tagged_with(["ruby", "java"], :any => true, :order_by_matching_tag_count => true, :order => 'taggable_models.name').to_a.should == [steve, bob, frank]
+    TaggableModel.tagged_with(["c++", "fitter"], :any => true, :order_by_matching_tag_count => true, :order => 'taggable_models.name').to_a.should == [steve, bob]
+    TaggableModel.tagged_with(["depressed", "css"], :any => true, :order_by_matching_tag_count => true, :order => 'taggable_models.name').to_a.should == [frank, bob]
+    TaggableModel.tagged_with(["fitter", "happier", "more productive", "c++", "java", "ruby"], :any => true, :order_by_matching_tag_count => true, :order => 'taggable_models.name').to_a.should == [steve, bob, frank]
+    TaggableModel.tagged_with(["c++", "java", "ruby", "fitter"], :any => true, :order_by_matching_tag_count => true, :order => 'taggable_models.name').to_a.should == [steve, bob, frank]
+  end
+
   context "wild: true" do
     it "should use params as wildcards" do
       bob = TaggableModel.create(:name => "Bob", :tag_list => "bob, tricia")


### PR DESCRIPTION
See issue #467.

Add option to order by number of matching tags when using `.tagged_with` with the `:any => true` option.
### Option

``` ruby
:order_by_matching_tag_count => true
```
### Option

``` ruby
TaggableModel.tagged_with(["a", "b", "c"], :any => true, :order_by_matching_tag_count => true)
```
### Example usage:

``` ruby
bob = TaggableModel.create(:name => "Bob", :tag_list => "fitter, happier, more productive")
frank = TaggableModel.create(:name => "Frank", :tag_list => "fitter, comfortable, eating well, sleeping well")
steve = TaggableModel.create(:name => 'Steve', :tag_list => 'fitter, comfortable, more productive, at ease')
earl = TaggableModel.create(:name => 'Earl', :tag_list => 'comfortable, sleeping well, eating well, self-employed')

TaggableModel.tagged_with(["fitter", "comfortable", "eating well", "sleeping well"], :any => true, :order_by_matching_tag_count => true)
# = [frank, earl, steve, bob]
```

Frank matches 4 tags
Earl matches 3 tags
Steve matches 2 tags
Bob matches 1 tag
### Additional ordering:

If additional order conditions are specified using the `:order` option, they will be included as secondary orders: e.g.:

``` ruby
TaggableModel.tagged_with(["a", "b", "c"], :any => true, 
                                           :order_by_matching_tag_count => true,
                                           :order => "taggable_models.name ASC")
```

Will order by tag count (descending) first, then model's name attribute second.

1 spec test included. Tests passing for me locally.
