### PR TITLE
Allow resetting of tag_lists and cached_tag_lists

### DIFF
--- a/lib/acts_as_taggable_on/acts_as_taggable_on/cache.rb
+++ b/lib/acts_as_taggable_on/acts_as_taggable_on/cache.rb
@@ -49,6 +49,10 @@ module ActsAsTaggableOn::Taggable
             def self.caching_#{tag_type.singularize}_list?
               caching_tag_list_on?("#{tag_type}")
             end
+
+            def reset_cached_#{tag_type.singularize}_list
+              reset_cached_tag_list_on("#{tag_type}")
+            end
           RUBY
         end
       end
@@ -64,17 +68,25 @@ module ActsAsTaggableOn::Taggable
     end
 
     module InstanceMethods
+      def reset_cached_tag_list_on(tag_type)
+        reset_tag_list_on(tag_type)
+        save_cached_tag_list_on(tag_type)
+      end
+
       def save_cached_tag_list
         tag_types.map(&:to_s).each do |tag_type|
-          if self.class.send("caching_#{tag_type.singularize}_list?")
-            if tag_list_cache_set_on(tag_type)
-              list = tag_list_cache_on(tag_type).to_a.flatten.compact.join(', ')
-              self["cached_#{tag_type.singularize}_list"] = list
-            end
+          save_cached_tag_list_on(tag_type)
+        end
+        true
+      end
+
+      def save_cached_tag_list_on(tag_type)
+        if self.class.send("caching_#{tag_type.singularize}_list?")
+          if tag_list_cache_set_on(tag_type)
+            list = tag_list_cache_on(tag_type).to_a.flatten.compact.join(', ')
+            self["cached_#{tag_type.singularize}_list"] = list
           end
         end
-
-        true
       end
     end
 

--- a/lib/acts_as_taggable_on/acts_as_taggable_on/core.rb
+++ b/lib/acts_as_taggable_on/acts_as_taggable_on/core.rb
@@ -50,6 +50,10 @@ module ActsAsTaggableOn::Taggable
             def all_#{tags_type}_list
               all_tags_list_on('#{tags_type}')
             end
+
+            def reset_#{tag_type}_list
+              reset_tag_list_on("#{tags_type}")
+            end
           RUBY
         end
       end
@@ -246,6 +250,11 @@ module ActsAsTaggableOn::Taggable
 
     def cached_tag_list_on(context)
       self["cached_#{context.to_s.singularize}_list"]
+    end
+
+    def reset_tag_list_on(context)
+      variable_name = "@#{context.to_s.singularize}_list"
+      instance_variable_set variable_name, ActsAsTaggableOn::TagList.new(tags_on(context).map(&:name))
     end
 
     def tag_list_cache_set_on(context)

--- a/spec/acts_as_taggable_on/caching_spec.rb
+++ b/spec/acts_as_taggable_on/caching_spec.rb
@@ -72,6 +72,13 @@ describe "Acts As Taggable On" do
       @taggable.save!
       @taggable.tag_list.sort.should == %w(awesome epic).sort
     end
+
+    it 'should update cache when tag list is reset' do
+      @taggable.update_attributes(:tag_list => 'awesome')
+      @taggable.tags.first.update_attributes(:name => 'epic')
+      @taggable.reset_cached_tag_list
+      @taggable.cached_tag_list.should == 'epic'
+    end
   end
 
 end

--- a/spec/acts_as_taggable_on/taggable_spec.rb
+++ b/spec/acts_as_taggable_on/taggable_spec.rb
@@ -32,6 +32,7 @@ describe "Taggable To Preserve Order" do
     [:tags, :colours].each do |type|
       @taggable.respond_to?("#{type.to_s.singularize}_list").should be_true
       @taggable.respond_to?("#{type.to_s.singularize}_list=").should be_true
+      @taggable.respond_to?("reset_#{type.to_s.singularize}_list").should be_true
       @taggable.respond_to?("all_#{type.to_s}_list").should be_true
     end
   end
@@ -537,6 +538,13 @@ describe "Taggable" do
 
       @taggable.reload
       @taggable.tag_list_on(:test).should == ["hello"]
+    end
+
+    it "should be able to reset tag list" do
+      @taggable.update_attributes(:tag_list => 'awesome')
+      @taggable.tags.first.update_attributes(:name => 'epic')
+      @taggable.reset_tag_list
+      @taggable.tag_list.should == %w(epic)
     end
   end
 


### PR DESCRIPTION
We have a tag admin area and when a tag was renamed we didn't have an easy way to update the associated cached tag lists of objects with that tag. This patch doesn't add the functionality directly, but it does give a helper method so you can loop through object.tagged_with(some_tag) and then refresh the object's cached tag list. I'm open to add more of this into the gem too, but wanted to start small and see if there is interest first.

Also, this is my first patch for this project so any feedback you have on code organization, format, or anything else, just let me know. Thanks!
