### PR TITLE
Add :separate_owned_tags option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ As such, a _Feature_ would map to either major or minor. A _bug fix_ to a patch.
 * Breaking Changes
 * Features
   * [@jamesburke-examtime #467 Add :order_by_matching_tag_count option](https://github.com/mbleigh/acts-as-taggable-on/pull/469)
+  * [@DmitryTsepelev #482 Add :separate_owned_tags option](https://github.com/mbleigh/acts-as-taggable-on/pull/482)
 * Fixes
   * [@rafael #406 Dirty attributes not correctly derived](https://github.com/mbleigh/acts-as-taggable-on/pull/406)
   * [@bzbnhang #440 Did not respect strict_case_match](https://github.com/mbleigh/acts-as-taggable-on/pull/440)

--- a/README.md
+++ b/README.md
@@ -339,6 +339,12 @@ If you want to change the default delimiter (it defaults to ','). You can also p
 ActsAsTaggableOn.delimiter = ','
 ```
 
+Owned tags are not included into tag_list by default. If you want to change this behaviour:
+
+```ruby
+ActsAsTaggableOn.separate_owned_tags = false
+```
+
 ## Contributors
 
 We have a long list of valued contributors. [Check them all](https://github.com/mbleigh/acts-as-taggable-on/contributors)

--- a/lib/acts-as-taggable-on.rb
+++ b/lib/acts-as-taggable-on.rb
@@ -28,7 +28,7 @@ module ActsAsTaggableOn
 
   class Configuration
     attr_accessor :delimiter, :force_lowercase, :force_parameterize,
-      :strict_case_match, :remove_unused_tags
+      :strict_case_match, :remove_unused_tags, :separate_owned_tags
 
     def initialize
       @delimiter = ','
@@ -36,6 +36,7 @@ module ActsAsTaggableOn
       @force_parameterize = false
       @strict_case_match = false
       @remove_unused_tags = false
+      @separate_owned_tags = true
     end
   end
 

--- a/lib/acts_as_taggable_on/acts_as_taggable_on/core.rb
+++ b/lib/acts_as_taggable_on/acts_as_taggable_on/core.rb
@@ -295,7 +295,8 @@ module ActsAsTaggableOn::Taggable
     ##
     # Returns all tags that are not owned of a given context
     def tags_on(context)
-      scope = base_tags.where(["#{ActsAsTaggableOn::Tagging.table_name}.context = ? AND #{ActsAsTaggableOn::Tagging.table_name}.tagger_id IS NULL", context.to_s])
+      scope = base_tags.where(["#{ActsAsTaggableOn::Tagging.table_name}.context = ?", context.to_s])
+      scope = scope.where("#{ActsAsTaggableOn::Tagging.table_name}.tagger_id IS NULL") if ActsAsTaggableOn.separate_owned_tags
       # when preserving tag order, return tags in created order
       # if we added the order to the association this would always apply
       scope = scope.order("#{ActsAsTaggableOn::Tagging.table_name}.id") if self.class.preserve_tag_order?

--- a/spec/acts_as_taggable_on/tagger_spec.rb
+++ b/spec/acts_as_taggable_on/tagger_spec.rb
@@ -124,6 +124,24 @@ describe "Tagger" do
     @taggable.all_tags_list.sort.should == %w(ruby scheme).sort
   end
 
+  it "should not separate owned taggings if separate_owned_tags option disabled" do
+    @taggable.update_attributes(:tag_list => 'general')
+    @user.tag(@taggable, :with => 'owned', :on => :tags)
+
+    @taggable.reload
+    @taggable.tag_list.should == %w(general)
+
+    ActsAsTaggableOn.separate_owned_tags = false
+
+    @taggable.reload
+    @taggable.tag_list.should == %w(general owned)
+
+    ActsAsTaggableOn.separate_owned_tags = true
+
+    @taggable.reload
+    @taggable.tag_list.should == %w(general)
+  end
+
   it "is tagger" do
     @user.is_tagger?.should(be_true)
   end


### PR DESCRIPTION
In my current project I've faced the problem that was described in [issue #52](https://github.com/mbleigh/acts-as-taggable-on/issues/52): I want to get all tags (owned and not owned) using method tag_list. I've added option `separate_owned_tags` which is true by default, so it won't break any existing functionality.
