### PR TITLE
add support for the protected_attributes backward compatibility gem

### DIFF
--- a/lib/acts_as_taggable_on/tag.rb
+++ b/lib/acts_as_taggable_on/tag.rb
@@ -1,4 +1,10 @@
 # coding: utf-8
+
+begin
+  require 'protected_attributes'
+rescue LoadError
+end
+
 module ActsAsTaggableOn
   class Tag < ::ActiveRecord::Base
     extend ActsAsTaggableOn::Utils

--- a/lib/acts_as_taggable_on/tagging.rb
+++ b/lib/acts_as_taggable_on/tagging.rb
@@ -1,3 +1,8 @@
+begin
+  require 'protected_attributes'
+rescue LoadError
+end
+
 module ActsAsTaggableOn
   class Tagging < ::ActiveRecord::Base #:nodoc:
     attr_accessible :tag,


### PR DESCRIPTION
it must be required before checking the existence of ActiveModel::MassAssignmentSecurity
