### PR TITLE
Match_all respects context (v3.0.1 backport?)

### DIFF
--- a/lib/acts_as_taggable_on/acts_as_taggable_on/core.rb
+++ b/lib/acts_as_taggable_on/acts_as_taggable_on/core.rb
@@ -185,6 +185,7 @@ module ActsAsTaggableOn::Taggable
                    "  ON #{taggings_alias}.taggable_id = #{quote}#{table_name}#{quote}.#{primary_key}" +
                    " AND #{taggings_alias}.taggable_type = #{quote_value(base_class.name, nil)}"
 
+          joins << " AND " + sanitize_sql(["#{taggings_alias}.context = ?", context.to_s]) if context
 
           group_columns = ActsAsTaggableOn::Tag.using_postgresql? ? grouped_column_names_for(self) : "#{table_name}.#{primary_key}"
           group = group_columns

--- a/spec/acts_as_taggable_on/taggable_spec.rb
+++ b/spec/acts_as_taggable_on/taggable_spec.rb
@@ -411,6 +411,14 @@ describe "Taggable" do
     TaggableModel.tagged_with("fitter, happier", :match_all => true).to_a.should == [steve]
   end
 
+  it "should be able to find tagged with only the matching tags for a context" do
+    bob = TaggableModel.create(:name => "Bob", :tag_list => "lazy, happier", :skill_list => "ruby, rails, css")
+    frank = TaggableModel.create(:name => "Frank", :tag_list => "fitter, happier, inefficient", :skill_list => "css")
+    steve = TaggableModel.create(:name => 'Steve', :tag_list => "fitter, happier", :skill_list => "ruby, rails, css")
+
+    TaggableModel.tagged_with("css", :on => :skills, :match_all => true).to_a.should == [frank]
+  end
+
   it "should be able to find tagged with some excluded tags" do
     bob = TaggableModel.create(:name => "Bob", :tag_list => "happier, lazy")
     frank = TaggableModel.create(:name => "Frank", :tag_list => "happier")


### PR DESCRIPTION
I found what I think is a bug when using `match_all` with a context. Previously with a query like

``` ruby
TaggableModel.tagged_with("css", :on => :skills, :match_all => true)
```

Only TaggedModels which had css as the only tag in any context would be returned, excluding models which had tags in other contexts, but only css in the skills context. With these changes `match_all` only applies to a specific context if one is given.
