### PR TITLE
Fix downcasing of unicode tag names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ As such, a _Feature_ would map to either major or minor. A _bug fix_ to a patch.
   * [@rgould #417 Let '.count' work when tagged_with is accompanied by a group clause](https://github.com/mbleigh/acts-as-taggable-on/pull/417)
   * [@developer88 #461 Move 'Distinct' out of select string and use .uniq instead](https://github.com/mbleigh/acts-as-taggable-on/pull/461)
   * [@gerard-leijdekkers #473 Fixed down migration index name](https://github.com/mbleigh/acts-as-taggable-on/pull/473)
+  * [@leo-souza #492 Fix downcasing of unicode tag names](https://github.com/mbleigh/acts-as-taggable-on/pull/492)
 * Misc
   * [@billychan #463 Thread safe support](https://github.com/mbleigh/acts-as-taggable-on/pull/463)
   * [@billychan #386 Add parse:true instructions to README](https://github.com/mbleigh/acts-as-taggable-on/pull/386)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@
 2. Install the gem dependencies: `bundle install`
 3. Make the changes you want and back them up with tests.
   * [Run the tests](https://github.com/mbleigh/acts-as-taggable-on#testing) (`bundle exec rake spec`)
-4. Update the CHAGELOG.md file with your changes and give yourself credit
+4. Update the CHANGELOG.md file with your changes and give yourself credit
 5. Commit and create a pull request with details as to what has been changed and why
   * Use well-described, small (atomic) commits.
   * Include links to any relevant github issues.

--- a/lib/acts_as_taggable_on/tag.rb
+++ b/lib/acts_as_taggable_on/tag.rb
@@ -38,7 +38,7 @@ module ActsAsTaggableOn
         where(clause)
       else
         clause = list.map { |tag|
-          lowercase_ascii_tag = as_8bit_ascii(tag).downcase
+          lowercase_ascii_tag = as_8bit_ascii(tag, true)
           sanitize_sql(["lower(name) = ?", lowercase_ascii_tag])
         }.join(" OR ")
         where(clause)
@@ -103,7 +103,7 @@ module ActsAsTaggableOn
         if ActsAsTaggableOn.strict_case_match
           as_8bit_ascii(str)
         else
-          as_8bit_ascii(str).downcase
+          as_8bit_ascii(str, true)
         end
       end
 
@@ -111,11 +111,13 @@ module ActsAsTaggableOn
         /mysql/ === ActiveRecord::Base.connection_config[:adapter] ? "BINARY " : nil
       end
 
-      def as_8bit_ascii(string)
+      def as_8bit_ascii(string, downcase=false)
+        string = string.to_s.dup.mb_chars
+        string.downcase! if downcase
         if defined?(Encoding)
-          string.to_s.dup.force_encoding('BINARY')
+          string.to_s.force_encoding('BINARY')
         else
-          string.to_s.mb_chars
+          string.to_s
         end
       end
     end

--- a/spec/acts_as_taggable_on/taggable_spec.rb
+++ b/spec/acts_as_taggable_on/taggable_spec.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 require 'spec_helper'
 
 describe "Taggable To Preserve Order" do
@@ -240,6 +241,18 @@ describe "Taggable" do
 
     ActsAsTaggableOn::Tag.all.size.should == 1
     TaggableModel.tagged_with("ruby").to_a.should == TaggableModel.tagged_with("Ruby").to_a
+  end
+
+  unless ActsAsTaggableOn::Tag.using_sqlite?
+    it "should not care about case for unicode names" do
+      ActsAsTaggableOn.strict_case_match = false
+      anya = TaggableModel.create(:name => "Anya", :tag_list => "ПРИВЕТ")
+      igor = TaggableModel.create(:name => "Igor", :tag_list => "привет")
+      katia = TaggableModel.create(:name => "Katia", :tag_list => "ПРИВЕТ")
+
+      ActsAsTaggableOn::Tag.all.size.should == 1
+      TaggableModel.tagged_with("привет").to_a.should == TaggableModel.tagged_with("ПРИВЕТ").to_a
+    end
   end
 
   it "should be able to get tag counts on model as a whole" do


### PR DESCRIPTION
I ran into some issues when a tag name contains upcased unicode chars. 
It happens in both creation and retrieving: 
- It doesn't find the previous tag when a second tag is being created and duplicates it. 
- When `tagged_with` is called, it returns an empty array, even when calling with the exact tag name.
  Examples:

``` ruby
Post.create(title: 'First', tag_list: 'Ruby')
Post.create(title: 'Second', tag_list: 'ruby')
Post.create(title: 'Third', tag_list: 'Ábaco')
Post.create(title: 'Fourth', tag_list: 'ábaco')
ActsAsTaggableOn::Tag.all
#<ActiveRecord::Relation [
  #<ActsAsTaggableOn::Tag id: 1, name: "Ruby">, 
  #<ActsAsTaggableOn::Tag id: 2, name: "Ábaco">, 
  #<ActsAsTaggableOn::Tag id: 3, name: "ábaco">]>

Post.tagged_with('ruby')
#<ActiveRecord::Relation [
  #<Post id: 1, title: "First", body: nil>,
  #<Post id: 2, title: "Second", body: nil>]>
Post.tagged_with('Ruby')
 #<ActiveRecord::Relation [
  #<Post id: 1, title: "First", body: nil>,
  #<Post id: 2, title: "Second", body: nil>]>
Post.tagged_with('ábaco')
#<ActiveRecord::Relation []>
Post.tagged_with('Ábaco')
#<ActiveRecord::Relation []>
```

This behaviour was introduced when `.force_encoding('BINARY')` was added in `Tag` class, which was being called before downcasing the string

When sqlite is being used, the only way around this is loading the ICU extension.

PR #472 only fixes the tagged_with part of this issue.
