### PR TITLE
Rename Compatibility methods to reduce chance of conflicts

### DIFF
--- a/lib/acts_as_taggable_on/acts_as_taggable_on/compatibility.rb
+++ b/lib/acts_as_taggable_on/acts_as_taggable_on/compatibility.rb
@@ -1,15 +1,15 @@
 module ActsAsTaggableOn::Compatibility
-  def has_many_with_compatibility(name, options = {}, &extention)
+  def has_many_with_taggable_compatibility(name, options = {}, &extention)
     if ActsAsTaggableOn::Utils.active_record4?
-      scope, opts = build_scope_and_options(options)
+      scope, opts = build_taggable_scope_and_options(options)
       has_many(name, scope, opts, &extention)
     else
       has_many(name, options, &extention)
     end
   end
 
-  def build_scope_and_options(opts)
-    scope_opts, opts = parse_options(opts)
+  def build_taggable_scope_and_options(opts)
+    scope_opts, opts = parse_taggable_options(opts)
 
     unless scope_opts.empty?
       scope = -> {
@@ -21,7 +21,7 @@ module ActsAsTaggableOn::Compatibility
     [nil, opts]
   end
 
-  def parse_options(opts)
+  def parse_taggable_options(opts)
     scope_opts = {}
     [:order, :having, :select, :group, :limit, :offset, :readonly].each do |o|
       scope_opts[o] = opts.delete o if opts[o]

--- a/lib/acts_as_taggable_on/acts_as_taggable_on/core.rb
+++ b/lib/acts_as_taggable_on/acts_as_taggable_on/core.rb
@@ -23,14 +23,14 @@ module ActsAsTaggableOn::Taggable
           class_eval do
             # when preserving tag order, include order option so that for a 'tags' context
             # the associations tag_taggings & tags are always returned in created order
-            has_many_with_compatibility context_taggings, as: :taggable,
+            has_many_with_taggable_compatibility context_taggings, as: :taggable,
                                         dependent: :destroy,
                                         class_name: 'ActsAsTaggableOn::Tagging',
                                         order: taggings_order,
                                         conditions: ["#{ActsAsTaggableOn::Tagging.table_name}.context = (?)", tags_type],
                                         include: :tag
 
-            has_many_with_compatibility context_tags, through: context_taggings,
+            has_many_with_taggable_compatibility context_tags, through: context_taggings,
                                         source: :tag,
                                         class_name: 'ActsAsTaggableOn::Tag',
                                         order: taggings_order

--- a/lib/acts_as_taggable_on/tagger.rb
+++ b/lib/acts_as_taggable_on/tagger.rb
@@ -15,14 +15,14 @@ module ActsAsTaggableOn
       #   end
       def acts_as_tagger(opts={})
         class_eval do
-          has_many_with_compatibility :owned_taggings,
+          has_many_with_taggable_compatibility :owned_taggings,
             opts.merge(
               as: :tagger,
               dependent: :destroy,
               class_name: 'ActsAsTaggableOn::Tagging'
             )
 
-          has_many_with_compatibility :owned_tags,
+          has_many_with_taggable_compatibility :owned_tags,
                                       through: :owned_taggings,
                                       source: :tag,
                                       class_name: 'ActsAsTaggableOn::Tag',


### PR DESCRIPTION
Hi - I ran into problems with AATO because I also use FlagShihTzu, which also has a parse_options method mixed into ActiveRecord::Base.  I renamed a couple of methods that sounded ambiguously named - WDYT?
