### PR TITLE
Fixed tag_cloud helper to actually generate the correct css tags

### DIFF
--- a/lib/acts_as_taggable_on/tags_helper.rb
+++ b/lib/acts_as_taggable_on/tags_helper.rb
@@ -4,10 +4,10 @@ module ActsAsTaggableOn
     def tag_cloud(tags, classes)
       return [] if tags.empty?
 
-      max_count = tags.sort_by(&:count).last.count.to_f
+      max_count = tags.sort_by(&:taggings_count).last.taggings_count.to_f
 
       tags.each do |tag|
-        index = ((tag.count / max_count) * (classes.size - 1))
+        index = ((tag.taggings_count / max_count) * (classes.size - 1))
         yield tag, classes[index.nan? ? 0 : index.round]
       end
     end


### PR DESCRIPTION
Changed the count method to taggings_count, which looks to be a true property on the ActsAsTaggableOn::Tag object, and fixes the tag_cloud helper.

Should fix Issue #554
