### PR TITLE
add back the taggables index in the taggings table

### DIFF
--- a/db/migrate/4_add_missing_taggable_index.rb
+++ b/db/migrate/4_add_missing_taggable_index.rb
@@ -1,0 +1,9 @@
+class AddMissingTaggableIndex < ActiveRecord::Migration
+  def self.up
+    add_index :taggings, [:taggable_id, :taggable_type, :context]
+  end
+
+  def self.down
+    remove_index :taggings, [:taggable_id, :taggable_type, :context]
+  end
+end


### PR DESCRIPTION
Resolves issue https://github.com/mbleigh/acts-as-taggable-on/issues/509

As explained in the bug, taggings_idx can only be used if tag_id is specified in the where clause due to the nature of compound indexes. This means the following query requires a full table scan: "what are all the tags on this taggable?"

This a regression that is fixed by re-adding a compound index on [:taggable_id, :taggable_type, :context]
