### PR TITLE
`ActsAsTaggableOn.remove_unused_tags` doesn't work

### DIFF
--- a/lib/acts_as_taggable_on/tagging.rb
+++ b/lib/acts_as_taggable_on/tagging.rb
@@ -32,7 +32,7 @@ module ActsAsTaggableOn
 
     def remove_unused_tags
       if ActsAsTaggableOn.remove_unused_tags
-        tag.destroy if tag.taggings_count.zero?
+        tag.destroy if tag.reload.taggings_count.zero?
       end
     end
   end

--- a/spec/acts_as_taggable_on/tagging_spec.rb
+++ b/spec/acts_as_taggable_on/tagging_spec.rb
@@ -38,6 +38,17 @@ describe ActsAsTaggableOn::Tagging do
     expect(another_taggable.tag_list.sort).to eq(%w(very serious bug).sort)
   end
 
+  it 'should destroy unused tags after tagging destroyed' do
+    previous_setting = ActsAsTaggableOn.remove_unused_tags
+    ActsAsTaggableOn.remove_unused_tags = true
+    ActsAsTaggableOn::Tag.destroy_all
+    @taggable = TaggableModel.create(name: 'Bob Jones')
+    @taggable.update_attribute :tag_list, 'aaa,bbb,ccc'
+    @taggable.update_attribute :tag_list, ''
+    expect(ActsAsTaggableOn::Tag.count).to eql(0)
+    ActsAsTaggableOn.remove_unused_tags = previous_setting
+  end
+
   pending 'context scopes' do
     describe '.by_context'
 


### PR DESCRIPTION
`tag.destroy` will never execute since `taggings_count` was cached in memory.
- ruby (2.1.2)
- rails (4.1.1)
- acts-as-taggable-on (3.2.6)
