### PR TITLE
Provide prefix option in tagged_with method in tag.rb for prefix match.

### DIFF
--- a/lib/acts_as_taggable_on/tag.rb
+++ b/lib/acts_as_taggable_on/tag.rb
@@ -55,6 +55,13 @@ module ActsAsTaggableOn
       where(clause)
     end
 
+    def self.named_with_prefix_any(list)
+      clause = list.map { |tag|
+        sanitize_sql(["name #{ActsAsTaggableOn::Utils.like_operator} ? ESCAPE '!'", "#{ActsAsTaggableOn::Utils.escape_like(tag.to_s)}%"])
+      }.join(' OR ')
+      where(clause)
+    end
+
     ### CLASS METHODS:
 
     def self.find_or_create_with_like_by_name(name)

--- a/lib/acts_as_taggable_on/taggable/core.rb
+++ b/lib/acts_as_taggable_on/taggable/core.rb
@@ -126,6 +126,8 @@ module ActsAsTaggableOn::Taggable
           # get tags, drop out if nothing returned (we need at least one)
           tags = if options.delete(:wild)
                    ActsAsTaggableOn::Tag.named_like_any(tag_list)
+                 elsif options.delete(:prefix)
+                   ActsAsTaggableOn::Tag.named_with_prefix_any(tag_list)
                  else
                    ActsAsTaggableOn::Tag.named_any(tag_list)
                  end


### PR DESCRIPTION
Currently :wild supports substring match only and not specifically prefix match.
