### PR TITLE
touch tagging belongs_to associations

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,12 +360,6 @@ If you want to change the default delimiter (it defaults to ','). You can also p
 ActsAsTaggableOn.delimiter = ','
 ```
 
-If you would like tags to be touched when they're added/removed:
-
-```ruby
-ActsAsTaggableOn.touch_tags = true
-```
-
 If you would like taggables to be touched when tags are added/removed:
 
 ```ruby
@@ -376,6 +370,12 @@ If you would like taggers to be touched when tags are added/removed:
 
 ```ruby
 ActsAsTaggableOn.touch_taggers = true
+```
+
+If you would like tags to be touched when they're added/removed (must also run: `rails g migration AddUpdatedAtToTags updated_at:datetime`):
+
+```ruby
+ActsAsTaggableOn.touch_tags = true
 ```
 
 *NOTE: SQLite by default can't upcase or downcase multibyte characters, resulting in unwanted behavior. Load the SQLite ICU extension for proper handle of such characters. [See docs](http://www.sqlite.org/src/artifact?ci=trunk&filename=ext/icu/README.txt)*

--- a/README.md
+++ b/README.md
@@ -328,6 +328,8 @@ CSS:
 
 ## Configuration
 
+To configure `acts_as_taggable_on`, place any of these directives in `config/initializers/acts_as_taggable_on.rb`.
+
 If you would like to remove unused tag objects after removing taggings, add:
 
 ```ruby

--- a/README.md
+++ b/README.md
@@ -360,6 +360,24 @@ If you want to change the default delimiter (it defaults to ','). You can also p
 ActsAsTaggableOn.delimiter = ','
 ```
 
+If you would like tags to be touched when they're added/removed:
+
+```ruby
+ActsAsTaggableOn.touch_tags = true
+```
+
+If you would like taggables to be touched when tags are added/removed:
+
+```ruby
+ActsAsTaggableOn.touch_taggables = true
+```
+
+If you would like taggers to be touched when tags are added/removed:
+
+```ruby
+ActsAsTaggableOn.touch_taggers = true
+```
+
 *NOTE: SQLite by default can't upcase or downcase multibyte characters, resulting in unwanted behavior. Load the SQLite ICU extension for proper handle of such characters. [See docs](http://www.sqlite.org/src/artifact?ci=trunk&filename=ext/icu/README.txt)*
 
 ## Contributors

--- a/lib/acts-as-taggable-on.rb
+++ b/lib/acts-as-taggable-on.rb
@@ -57,7 +57,7 @@ module ActsAsTaggableOn
 
   class Configuration
     attr_accessor :delimiter, :force_lowercase, :force_parameterize,
-                  :strict_case_match, :touch_tags, :touch_taggables, :touch_taggers
+                  :strict_case_match, :remove_unused_tags, :touch_tags, :touch_taggables, :touch_taggers
 
     def initialize
       @delimiter = ','

--- a/lib/acts-as-taggable-on.rb
+++ b/lib/acts-as-taggable-on.rb
@@ -57,7 +57,7 @@ module ActsAsTaggableOn
 
   class Configuration
     attr_accessor :delimiter, :force_lowercase, :force_parameterize,
-                  :strict_case_match, :remove_unused_tags
+                  :strict_case_match, :touch_tags, :touch_taggables, :touch_taggers
 
     def initialize
       @delimiter = ','
@@ -65,6 +65,9 @@ module ActsAsTaggableOn
       @force_parameterize = false
       @strict_case_match = false
       @remove_unused_tags = false
+      @touch_tags = false
+      @touch_taggables = false
+      @touch_taggers = false
     end
   end
 

--- a/lib/acts_as_taggable_on/tagging.rb
+++ b/lib/acts_as_taggable_on/tagging.rb
@@ -11,9 +11,9 @@ module ActsAsTaggableOn
                     :tagger_type,
                     :tagger_id if defined?(ActiveModel::MassAssignmentSecurity)
 
-    belongs_to :tag, class_name: 'ActsAsTaggableOn::Tag' , counter_cache: true, touch: true
-    belongs_to :taggable, polymorphic: true, touch: true
-    belongs_to :tagger,   polymorphic: true, touch: true
+    belongs_to :tag, class_name: 'ActsAsTaggableOn::Tag' , counter_cache: true
+    belongs_to :taggable, polymorphic: true
+    belongs_to :tagger,   polymorphic: true
 
     scope :owned_by, ->(owner) { where(tagger: owner) }
     scope :not_owned, -> { where(tagger_id: nil, tagger_type: nil) }
@@ -26,9 +26,16 @@ module ActsAsTaggableOn
 
     validates_uniqueness_of :tag_id, scope: [:taggable_type, :taggable_id, :context, :tagger_id, :tagger_type]
 
+    before_save :touch_associations
     after_destroy :remove_unused_tags
 
     private
+
+    def touch_associations
+      tag.touch if ActsAsTaggableOn.touch_tags
+      taggable.touch if ActsAsTaggableOn.touch_taggable
+      tagger.touch if ActsAsTaggableOn.touch_tagger
+    end
 
     def remove_unused_tags
       if ActsAsTaggableOn.remove_unused_tags

--- a/lib/acts_as_taggable_on/tagging.rb
+++ b/lib/acts_as_taggable_on/tagging.rb
@@ -33,8 +33,8 @@ module ActsAsTaggableOn
 
     def touch_associations
       tag.touch if ActsAsTaggableOn.touch_tags
-      taggable.touch if ActsAsTaggableOn.touch_taggable
-      tagger.touch if ActsAsTaggableOn.touch_tagger
+      taggable.touch if ActsAsTaggableOn.touch_taggables
+      tagger.touch if ActsAsTaggableOn.touch_taggers
     end
 
     def remove_unused_tags

--- a/lib/acts_as_taggable_on/tagging.rb
+++ b/lib/acts_as_taggable_on/tagging.rb
@@ -11,9 +11,9 @@ module ActsAsTaggableOn
                     :tagger_type,
                     :tagger_id if defined?(ActiveModel::MassAssignmentSecurity)
 
-    belongs_to :tag, class_name: 'ActsAsTaggableOn::Tag' , counter_cache: true
-    belongs_to :taggable, polymorphic: true
-    belongs_to :tagger,   polymorphic: true
+    belongs_to :tag, class_name: 'ActsAsTaggableOn::Tag' , counter_cache: true, touch: true
+    belongs_to :taggable, polymorphic: true, touch: true
+    belongs_to :tagger,   polymorphic: true, touch: true
 
     scope :owned_by, ->(owner) { where(tagger: owner) }
     scope :not_owned, -> { where(tagger_id: nil, tagger_type: nil) }

--- a/spec/internal/db/schema.rb
+++ b/spec/internal/db/schema.rb
@@ -3,6 +3,7 @@ ActiveRecord::Schema.define version: 0 do
     t.string :name
     t.integer :taggings_count, default: 0
     t.string :type
+    t.datetime :updated_at
   end
   add_index 'tags', ['name'], name: 'index_tags_on_name', unique: true
 
@@ -30,6 +31,7 @@ ActiveRecord::Schema.define version: 0 do
   create_table :taggable_models, force: true do |t|
     t.column :name, :string
     t.column :type, :string
+    t.column :updated_at, :datetime
   end
 
   create_table :non_standard_id_taggable_models, primary_key: 'an_id', force: true do |t|
@@ -62,6 +64,7 @@ ActiveRecord::Schema.define version: 0 do
 
   create_table :users, force: true do |t|
     t.column :name, :string
+    t.column :updated_at, :datetime
   end
 
   create_table :other_taggable_models, force: true do |t|


### PR DESCRIPTION
It'd be helpful for caching if taggable objects were touched when their tags change.
