### PR TITLE
fetch ids without instantiating records using pluck

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,13 +12,15 @@ As such, a _Feature_ would map to either major or minor. A _bug fix_ to a patch.
   * Performance
   * Misc
 
-### [3.4.0 / 2014-08-29](Master [changes](https://github.com/mbleigh/acts-as-taggable-on/compare/v3.3.0...v3.4.0)
+### [3.4.0 / 2014-08-29](https://github.com/mbleigh/acts-as-taggable-on/compare/v3.3.0...v3.4.0)
 
   * Features
     * [@ProGM Support for custom parsers for tags](https://github.com/mbleigh/acts-as-taggable-on/pull/579)
     * [@damzcodes #577 Popular feature](https://github.com/mbleigh/acts-as-taggable-on/pull/577)
   * Fixes
-    * [@twalpole Update for rails edge (4.2)]
+    * [@twalpole Update for rails edge (4.2)](https://github.com/mbleigh/acts-as-taggable-on/pull/583)
+  * Performance
+    * [@dontfidget #587 Use pluck instead of select](https://github.com/mbleigh/acts-as-taggable-on/pull/587)
 
 ### [3.3.0 / 2014-07-08](https://github.com/mbleigh/acts-as-taggable-on/compare/v3.2.6...v3.3.0)
 

--- a/lib/acts_as_taggable_on/taggable/collection.rb
+++ b/lib/acts_as_taggable_on/taggable/collection.rb
@@ -135,7 +135,7 @@ module ActsAsTaggableOn::Taggable
         table_name_pkey = "#{table_name}.#{primary_key}"
         if ActsAsTaggableOn::Utils.using_mysql?
           # See https://github.com/mbleigh/acts-as-taggable-on/pull/457 for details
-          scoped_ids = select(table_name_pkey).map(&:id)
+          scoped_ids = pluck(table_name_pkey)
           tagging_scope = tagging_scope.where("#{ActsAsTaggableOn::Tagging.table_name}.taggable_id IN (?)", scoped_ids)
         else
           tagging_scope = tagging_scope.where("#{ActsAsTaggableOn::Tagging.table_name}.taggable_id IN(#{safe_to_sql(select(table_name_pkey))})")


### PR DESCRIPTION
Not only is pluck more efficient for fetching ids, but instantiating a record with only an id can cause problems isfthere are after_find hooks that expect to have all the columns populated.  However, pluck was a rails 3.2 addition, so we have to test for it since this gem supports back to rails 3.0.0.
