### PR TITLE
fix owned ordered taggable bug

### DIFF
--- a/lib/acts_as_taggable_on/taggable/ownership.rb
+++ b/lib/acts_as_taggable_on/taggable/ownership.rb
@@ -82,7 +82,7 @@ module ActsAsTaggableOn::Taggable
           tags = find_or_create_tags_from_list_with_context(tag_list.uniq, context)
 
           # Tag objects for owned tags
-          owned_tags = owner_tags_on(owner, context)
+          owned_tags = owner_tags_on(owner, context).to_a
 
           # Tag maintenance based on whether preserving the created order of tags
           if self.class.preserve_tag_order?

--- a/spec/acts_as_taggable_on/tagger_spec.rb
+++ b/spec/acts_as_taggable_on/tagger_spec.rb
@@ -137,4 +137,17 @@ describe 'Tagger' do
     }).to_not change(ActsAsTaggableOn::Tagging, :count)
   end
 
+  it 'should change tags order in ordered taggable' do
+    @ordered_taggable = OrderedTaggableModel.create name: 'hey!'
+
+    @user.tag @ordered_taggable, with: 'tag, tag1', on: :tags
+    expect(@ordered_taggable.reload.tags_from(@user)).to eq(['tag', 'tag1'])
+
+    @user.tag @ordered_taggable, with: 'tag2, tag1', on: :tags
+    expect(@ordered_taggable.reload.tags_from(@user)).to eq(['tag2', 'tag1'])
+
+    @user.tag @ordered_taggable, with: 'tag1, tag2', on: :tags
+    expect(@ordered_taggable.reload.tags_from(@user)).to eq(['tag1', 'tag2'])
+  end
+
 end


### PR DESCRIPTION
Hi again guys.

I got an email from a dude who ran into a nasty bug.

For example you have an ordered taggable model:

``` ruby
class MyTaggable < ActiveRecord::Base
  acts_as_ordered_taggable
end
```

and a simple user model:

``` ruby
class User < AR::Base
  acts_as_tagger
end
```

Let's open rails console:

``` ruby
user = User.last
my_taggable = MyTaggable.last

# this model has already been tagged before
my_taggable.tags_from(user) # => ['tag1', 'tag2', 'tag3']
```

I chose tags and their order to get [into this block](https://github.com/mbleigh/acts-as-taggable-on/blob/master/lib/acts_as_taggable_on/taggable/ownership.rb#L94)

``` ruby
# then you wanna change tags and their order. 
@user.tag(@my_taggable, with: "tag3, tag2", on: :tags) #=> and you got....

ActiveRecord::StatementInvalid: PG::SyntaxError: ERROR:  syntax error at or near "0"
LINE 1: SELECT "tags".* FROM 0 INNER JOIN "taggings" ON "tags"."id" ...
                             ^
```

Because of this ["from" method](https://github.com/mbleigh/acts-as-taggable-on/blob/master/lib/acts_as_taggable_on/taggable/ownership.rb#L97) which is being called from Relation class instead of Array.

Here's a fix and a test that recreates this behaviour.
