### PR TITLE
Adds a fix to handle special characters combinations and MySQL

### DIFF
--- a/lib/acts_as_taggable_on/tag.rb
+++ b/lib/acts_as_taggable_on/tag.rb
@@ -32,17 +32,10 @@ module ActsAsTaggableOn
     end
 
     def self.named_any(list)
-      if ActsAsTaggableOn.strict_case_match
-        clause = list.map { |tag|
-          sanitize_sql(["name = #{binary}?", as_8bit_ascii(tag)])
-        }.join(' OR ')
-        where(clause)
-      else
-        clause = list.map { |tag|
-          sanitize_sql(['LOWER(name) = LOWER(?)', as_8bit_ascii(unicode_downcase(tag))])
-        }.join(' OR ')
-        where(clause)
-      end
+      clause = list.map { |tag|
+        sanitize_sql_for_named_any(tag).force_encoding('BINARY')
+      }.join(' OR ')
+      where(clause)
     end
 
     def self.named_like(name)
@@ -133,6 +126,14 @@ module ActsAsTaggableOn
           string.to_s.dup.force_encoding('BINARY')
         else
           string.to_s.mb_chars
+        end
+      end
+
+      def sanitize_sql_for_named_any(tag)
+        if ActsAsTaggableOn.strict_case_match
+          sanitize_sql(["name = #{binary}?", as_8bit_ascii(tag)])
+        else
+          sanitize_sql(['LOWER(name) = LOWER(?)', as_8bit_ascii(unicode_downcase(tag))])
         end
       end
     end

--- a/spec/acts_as_taggable_on/tag_spec.rb
+++ b/spec/acts_as_taggable_on/tag_spec.rb
@@ -46,6 +46,14 @@ describe ActsAsTaggableOn::Tag do
     end
   end
 
+  describe 'named any' do
+    context 'with some special characters combinations', if: using_mysql? do
+      it 'should not raise an invalid encoding exception' do
+        expect{ActsAsTaggableOn::Tag.named_any(["holä", "hol'ä"])}.not_to raise_error
+      end
+    end
+  end
+
   describe 'find or create by name' do
     before(:each) do
       @tag.name = 'awesome'
@@ -250,12 +258,18 @@ describe ActsAsTaggableOn::Tag do
       end
     end
 
-    it 'should not change enconding' do
+    it 'should not change encoding' do
       name = "\u3042"
       original_encoding = name.encoding
       record = ActsAsTaggableOn::Tag.find_or_create_with_like_by_name(name)
       record.reload
       expect(record.name.encoding).to eq(original_encoding)
+    end
+
+    context 'named any with some special characters combinations', if: using_mysql? do
+      it 'should not raise an invalid encoding exception' do
+        expect{ActsAsTaggableOn::Tag.named_any(["holä", "hol'ä"])}.not_to raise_error
+      end
     end
   end
 


### PR DESCRIPTION
Provides a fix along with its specs to prevent `Encoding:CompatibilityError` with some combinations of special characters when using MySQL.

Answers https://github.com/mbleigh/acts-as-taggable-on/issues/533
