### PR TITLE
Ensure taggings context aliases are maintained when joining taggings

### DIFF
--- a/lib/acts_as_taggable_on/taggable/core.rb
+++ b/lib/acts_as_taggable_on/taggable/core.rb
@@ -27,7 +27,7 @@ module ActsAsTaggableOn::Taggable
                                                  dependent: :destroy,
                                                  class_name: 'ActsAsTaggableOn::Tagging',
                                                  order: taggings_order,
-                                                 conditions: ["#{ActsAsTaggableOn::Tagging.table_name}.context = (?)", tags_type],
+                                                 conditions: {context: tags_type},
                                                  include: :tag
 
             has_many_with_taggable_compatibility context_tags, through: context_taggings,

--- a/spec/acts_as_taggable_on/acts_as_taggable_on_spec.rb
+++ b/spec/acts_as_taggable_on/acts_as_taggable_on_spec.rb
@@ -133,6 +133,22 @@ describe 'Acts As Taggable On' do
       expect(taggable1.find_matching_contexts_for(TaggableModel, :offerings, :needs)).to_not include(taggable1)
     end
 
+    it 'should ensure joins to multiple taggings maintain their contexts when aliasing' do
+      taggable1 = TaggableModel.create!(name: 'Taggable 1')
+
+      taggable1.offering_list = 'one'
+      taggable1.need_list = 'two'
+
+      taggable1.save
+
+      column = TaggableModel.connection.quote_column_name("context")
+      offer_alias = TaggableModel.connection.quote_table_name("taggings")
+      need_alias = TaggableModel.connection.quote_table_name("need_taggings_taggable_models_join")
+
+      expect(TaggableModel.joins(:offerings, :needs).to_sql).to include "#{offer_alias}.#{column}"
+      expect(TaggableModel.joins(:offerings, :needs).to_sql).to include "#{need_alias}.#{column}"
+    end
+
   end
 
   describe 'Tagging Contexts' do


### PR DESCRIPTION
Using stringified conditions means that the table aliasing fails with joins to multiple taggables

Test and patch included

Ref #273 
