### PR TITLE
Meet interface expectation for active record.

### DIFF
--- a/lib/acts_as_taggable_on/taggable/collection.rb
+++ b/lib/acts_as_taggable_on/taggable/collection.rb
@@ -169,7 +169,7 @@ module ActsAsTaggableOn::Taggable
     end
 
     module CalculationMethods
-      def count(column_name=:all)
+      def count(column_name=:all, options = {})
         # https://github.com/rails/rails/commit/da9b5d4a8435b744fcf278fffd6d7f1e36d4a4f2
         super
       end


### PR DESCRIPTION
Count must still accept a second parameter.
https://github.com/rails/rails/blob/0ef8a244231c355cab7f4d032efed51ef5ddfe99/activerecord/lib/active_record/relation/calculations.rb#L30

Causes issues with gems that expect this interface to be consistent.

I'm not entirely sure why this method is here. I assume its for a reason.

This change should be backported to other branches.
