### PR TITLE
sha_prefix should not be random

### DIFF
--- a/lib/acts_as_taggable_on/utils.rb
+++ b/lib/acts_as_taggable_on/utils.rb
@@ -18,7 +18,7 @@ module ActsAsTaggableOn
       end
 
       def sha_prefix(string)
-        Digest::SHA1.hexdigest("#{string}#{rand}")[0..6]
+        Digest::SHA1.hexdigest(string)[0..6]
       end
 
       def active_record4?

--- a/spec/acts_as_taggable_on/utils_spec.rb
+++ b/spec/acts_as_taggable_on/utils_spec.rb
@@ -13,4 +13,11 @@ describe ActsAsTaggableOn::Utils do
       expect(ActsAsTaggableOn::Utils.like_operator).to eq('LIKE')
     end
   end
+
+  describe '#sha_prefix' do
+    it 'should return a consistent prefix for a given word' do
+      expect(ActsAsTaggableOn::Utils.sha_prefix('kittens')).to eq(ActsAsTaggableOn::Utils.sha_prefix('kittens'))
+      expect(ActsAsTaggableOn::Utils.sha_prefix('puppies')).not_to eq(ActsAsTaggableOn::Utils.sha_prefix('kittens'))
+    end
+  end
 end


### PR DESCRIPTION
Hi there - `Utils::sha_prefix(string)` essentially returns a completely random hash every time you call it.  This is unexpected (at least to me), and prevents query caching where it's used as the join table alias.

I think the random behaviour originated in 713eb2919a4e63052d85e2aa9dfc4a59480514e4 (where it started out as a unique identifier), and got subsequently more confusing with be398de9ac6c9b801fdcb7f51ffe136fd2f68a42 and d9f0b77c09c5f9aab6099fc4c8d18326de58e842

How about this change?
