### PR TITLE
Fix encoding/accent raising  ActsAsTaggableOn::DuplicateTagError 

### DIFF
--- a/lib/acts_as_taggable_on/tag.rb
+++ b/lib/acts_as_taggable_on/tag.rb
@@ -105,7 +105,7 @@ module ActsAsTaggableOn
         if ActsAsTaggableOn.strict_case_match
           str
         else
-          unicode_downcase(str.to_s)
+          I18n.transliterate(unicode_downcase(str.to_s))
         end
       end
 

--- a/spec/acts_as_taggable_on/tag_spec.rb
+++ b/spec/acts_as_taggable_on/tag_spec.rb
@@ -115,8 +115,7 @@ describe ActsAsTaggableOn::Tag do
         include_context 'without unique index'
       end
 
-      it 'should find by name case sensitive' do
-        ActsAsTaggableOn.strict_case_match = true
+      it 'should find by name case sensitive', strict_case_match: true do
         expect {
           ActsAsTaggableOn::Tag.find_or_create_all_with_like_by_name('AWESOME')
         }.to change(ActsAsTaggableOn::Tag, :count).by(1)
@@ -134,8 +133,7 @@ describe ActsAsTaggableOn::Tag do
         include_context 'without unique index'
       end
 
-      it 'should find or create by name case sensitive' do
-        ActsAsTaggableOn.strict_case_match = true
+      it 'should find or create by name case sensitive', strict_case_match: true do
         expect {
           expect(ActsAsTaggableOn::Tag.find_or_create_all_with_like_by_name('AWESOME', 'awesome').map(&:name)).to eq(%w(AWESOME awesome))
         }.to change(ActsAsTaggableOn::Tag, :count).by(1)
@@ -150,6 +148,19 @@ describe ActsAsTaggableOn::Tag do
 
     it 'should return an empty array if no tags are specified' do
       expect(ActsAsTaggableOn::Tag.find_or_create_all_with_like_by_name([])).to be_empty
+    end
+
+    context 'accented characters', unless: using_sqlite? do
+      before(:each) do
+        @tag.name = 'spécifique'
+        @tag.save
+      end
+
+      it 'should find or create by name' do
+        expect {
+          ActsAsTaggableOn::Tag.find_or_create_all_with_like_by_name('specifique')
+        }.not_to change(ActsAsTaggableOn::Tag, :count)
+      end
     end
   end
 
@@ -214,15 +225,10 @@ describe ActsAsTaggableOn::Tag do
 
   end
 
-  describe 'when using strict_case_match' do
+  describe 'when using strict_case_match', strict_case_match: true do
     before do
-      ActsAsTaggableOn.strict_case_match = true
       @tag.name = 'awesome'
       @tag.save!
-    end
-
-    after do
-      ActsAsTaggableOn.strict_case_match = false
     end
 
     it 'should find by name' do

--- a/spec/acts_as_taggable_on/taggable_spec.rb
+++ b/spec/acts_as_taggable_on/taggable_spec.rb
@@ -278,7 +278,6 @@ describe 'Taggable' do
   end
 
   it 'should not care about case for unicode names', unless: using_sqlite? do
-    ActsAsTaggableOn.strict_case_match = false
     TaggableModel.create(name: 'Anya', tag_list: 'ПРИВЕТ')
     TaggableModel.create(name: 'Igor', tag_list: 'привет')
     TaggableModel.create(name: 'Katia', tag_list: 'ПРИВЕТ')
@@ -288,7 +287,6 @@ describe 'Taggable' do
   end
 
   context 'should be able to create and find tags in languages without capitalization :' do
-    ActsAsTaggableOn.strict_case_match = false
     {
         japanese: {name: 'Chihiro', tag_list: '日本の'},
         hebrew: {name: 'Salim', tag_list: 'עברית'},

--- a/spec/support/strict_case_match.rb
+++ b/spec/support/strict_case_match.rb
@@ -1,0 +1,11 @@
+RSpec.configure do |config|
+
+  config.before(:each, strict_case_match: true) do
+    ActsAsTaggableOn.strict_case_match = true
+  end
+
+  config.after(:each, strict_case_match: true) do
+    ActsAsTaggableOn.strict_case_match = false
+  end
+
+end


### PR DESCRIPTION
Creating a tag named "spécifique", then a tag named "specifique" would raise ActsAsTaggableOn::DuplicateTagError

SQL server being correctly configured recognizes that `"spécifique" == "specifique"`, but acts-as-taggable-on does not.

---

I implemented 2 things in this PR, sorry for the confusion but I was obliged to fix that spec bug in order to correctly deliver my PR. Here are the details:

**1) fix rspec bug**

Several specs was setting `ActsAsTaggableOn.strict_case_match = true` without reinitializing it after, which may input invalid settings for the other specs, and all depending on the order specs are run. I cleaned that by replacing all instances of
```
it 'should do something' do
  ActsAsTaggableOn.strict_case_match = true
  ...
end
```
by
```
it 'should do something', strict_case_match: true do
  ...
end
```

The `strict_case_match` flag correctly sets `ActsAsTaggableOn.strict_case_match = true` before the examples and reset it to `false` after the examples. 


**2) Use I18n transliterate for unicode comparison**

The main reason of this PR: In order to correctly compare strings such as "spécifique" and "specifique" I added `I18n.transliterate` to `Tag#comparable_name`. This also has the advantage to support I18n, so users of acts-as-taggable-on can use I18n to precisely define unicode comparison according to their language.

Example:
In english "Jürgen" would be compared to ASCII "Jurgen"
In german "Jürgen" would be compared to ASCII "Juergen"
And this can be set in locale yml files

More info: http://api.rubyonrails.org/classes/ActiveSupport/Inflector.html#method-i-transliterate

---

Seems to be also a fix for #227 
Let me know what you guys think
