### PR TITLE
Alter tagged_with(' ') to return full scope when exclude is true

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ User.tagged_with(['awesome', 'cool'], :on => :tags, :any => true).tagged_with(['
 
 You can also use `:wild => true` option along with `:any` or `:exclude` option. It will be looking for `%awesome%` and `%cool%` in SQL.
 
-__Tip:__ `User.tagged_with([])` or `User.tagged_with('')` will return `[]`, an empty set of records.
+__Tip:__ `User.tagged_with([])` or `User.tagged_with('')` will return `[]`, an empty set of records. However, `User.tagged_with([], :exclude => true)` or `User.tagged_with('', :exclude => true)` will return the full scope.
 
 
 ### Relationships

--- a/lib/acts_as_taggable_on/taggable/core.rb
+++ b/lib/acts_as_taggable_on/taggable/core.rb
@@ -89,7 +89,10 @@ module ActsAsTaggableOn::Taggable
         options = options.dup
         empty_result = where('1 = 0')
 
-        return empty_result if tag_list.empty?
+        if tag_list.empty?
+          return empty_result unless options.delete(:exclude)
+          return all
+        end
 
         joins = []
         conditions = []

--- a/spec/acts_as_taggable_on/taggable_spec.rb
+++ b/spec/acts_as_taggable_on/taggable_spec.rb
@@ -515,6 +515,17 @@ describe 'Taggable' do
     end
   end
 
+  context 'exclude: true' do
+    it 'should return the full scope for empty tags' do
+      TaggableModel.create(name: 'Bob', tag_list: 'happier, lazy')
+      TaggableModel.create(name: 'Frank', tag_list: 'happier')
+
+      ['', ' ', nil, []].each do |tag|
+        expect(TaggableModel.tagged_with(tag, exclude: true).size).to eq(2)
+      end
+    end
+  end
+
   it 'should options key not be deleted' do
     options = {:exclude => true}
     TaggableModel.tagged_with("foo", options)


### PR DESCRIPTION
Unexpected behavior of `Model.tagged_with( empty_value, exclude: true )` is documented in Issue #630. 

I have only added 1 test to verify the new lines of code, and it passes on my version of Ruby and Rails (Ruby 2.2.0 and Rails 4.2). 

This update could result in breakage for anyone who depends on `tagged_with(' ')` returning `[]` regardless of the value of `:exclude`.
