### PR TITLE
#623: updated README (added suggestion for manual column alteration).

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,9 +57,14 @@ Review the generated migrations then migrate :
 rake db:migrate
 ```
 
-MySql users should also apply a column change to get special characters
-work correctly for tag names, see [issue #623](https://github.com/mbleigh/acts-as-taggable-on/issues/623).
-Execute the following command in the MySql console:
+MySql users should also run the following rake task to get special characters
+work correctly for tag names, see [issue #623](https://github.com/mbleigh/acts-as-taggable-on/issues/623):
+
+```shell
+rake acts_as_taggable_on_engine:tag_names:collate
+```
+
+or, alternatively, execute the following command in the MySql console:
 
 ```shell
 USE my_wonderful_app_db;

--- a/README.md
+++ b/README.md
@@ -57,6 +57,15 @@ Review the generated migrations then migrate :
 rake db:migrate
 ```
 
+MySql users should also apply a column change to get special characters
+work correctly for tag names, see [issue #623](https://github.com/mbleigh/acts-as-taggable-on/issues/623).
+Execute the following command in the MySql console:
+
+```shell
+USE my_wonderful_app_db;
+ALTER TABLE tags MODIFY name VARCHAR(255) CHARACTER SET utf8 COLLATE utf8_bin;
+```
+
 #### Upgrading
 
 see [UPGRADING](UPGRADING.md)

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,8 @@
 require 'rubygems'
 require 'bundler/setup'
 
+import "./lib/tasks/tags_collate_utf8.rake"
+
 desc 'Default: run specs'
 task default: :spec
 

--- a/db/migrate/5_change_collation_for_tag_names.rb
+++ b/db/migrate/5_change_collation_for_tag_names.rb
@@ -1,0 +1,15 @@
+# This migration is added to circumvent issue #623 and have special characters
+# work properly
+class ChangeCollationForTagNames << ActiveRecord::Migration
+
+  def up
+    if ActsAsTaggableOn::Utils.using_mysql?
+     execute("ALTER TABLE tags MODIFY name varchar(255) CHARACTER SET utf8 COLLATE utf8_bin;") 
+    end
+  end
+
+  def down
+    
+  end
+
+end

--- a/lib/tasks/tags_collate_utf8.rake
+++ b/lib/tasks/tags_collate_utf8.rake
@@ -1,0 +1,17 @@
+# This rake task is to be run by MySql users only, and fixes the management of 
+# binary-encoded strings for tag 'names'. Issues: 
+# https://github.com/mbleigh/acts-as-taggable-on/issues/623
+
+namespace :acts_as_taggable_on_engine do
+
+  namespace :tag_names do
+
+    desc "Forcing collate of tag names to utf8_bin"
+    task :collate => [:environment] do |t, args|
+      puts "Changing collate for column 'name' of table 'tags'"
+      ActiveRecord::Migration.execute("ALTER TABLE tags MODIFY name varchar(255) CHARACTER SET utf8 COLLATE utf8_bin;")
+    end
+
+  end
+
+end


### PR DESCRIPTION
This is to fix special characters used in tag names (MySql only).
A tag 'name' is stored by the gem as 'binary encoded string', but if collation is not specified as 'utf8_bin' for that column, all the comparisons are not made properly and thus the unicity constraint expressed by the index 'index_tags_on_name' generate the error you experienced.

Thus for a quick circumvention, you could alter the 'tags' table in the column 'name':
<pre>
ALTER TABLE tags MODIFY name VARCHAR(255) CHARACTER SET utf8 COLLATE utf8_bin;
<pre>
