### PR TITLE
Changing ActsAsTaggable to ActsAsTaggableOn

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,7 +302,7 @@ Now you can use this parser, passing it as parameter:
 Or change it globally:
 
 ```ruby
-ActsAsTaggable.default_parser = MyParser
+ActsAsTaggableOn.default_parser = MyParser
 @user = User.new(:name => "Bobby")
 @user.tag_list = "east|south"
 @user.tag_list # => ["east", "south"]


### PR DESCRIPTION
The default parser change was still using ActsAsTaggable.default_parser