### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ end
 
 class UsersController < ApplicationController
   def user_params
-    params.require(:user).permit(:name, :tag_list => []) ## Rails 4 strong params usage
+    params.require(:user).permit(:name, :tag_list) ## Rails 4 strong params usage
   end
 end
 


### PR DESCRIPTION
removed the default array for tag_list. Rails4 didn't actually like this