### PR TITLE
#623 collation parameter is ignored if it generates an exception.

### DIFF
--- a/lib/acts-as-taggable-on.rb
+++ b/lib/acts-as-taggable-on.rb
@@ -106,7 +106,11 @@ WARNING
         if bincoll == true
           coll = 'utf8_bin'
         end
-        ActiveRecord::Migration.execute("ALTER TABLE tags MODIFY name varchar(255) CHARACTER SET utf8 COLLATE #{coll};")
+        begin
+          ActiveRecord::Migration.execute("ALTER TABLE tags MODIFY name varchar(255) CHARACTER SET utf8 COLLATE #{coll};")
+        rescue Exception => e
+          puts "Trapping #{e.class}: collation parameter ignored while migrating for the first time."
+        end
       end
     end
 


### PR DESCRIPTION
When migrations are run *for the first time* in a new project the 'force_binary_collation' parameter generates an exception while the application environment loads.
The proposed begin/rescue block solves the problem, trapping the exception being raised at the very first time the migration is run.