### PR TITLE
Remove broken and unnecessary select clause when calling #tagged_with([], any: true)

### DIFF
--- a/lib/acts_as_taggable_on/taggable/core.rb
+++ b/lib/acts_as_taggable_on/taggable/core.rb
@@ -153,7 +153,6 @@ module ActsAsTaggableOn::Taggable
           # don't need to sanitize sql, map all ids and join with OR logic
           tag_ids = tags.map { |t| quote_value(t.id, nil) }.join(', ')
           tagging_cond << " AND #{taggings_alias}.tag_id in (#{tag_ids})"
-          select_clause << " #{table_name}.*" unless context and tag_types.one?
 
           if owned_by
             tagging_cond << ' AND ' +
@@ -432,7 +431,7 @@ module ActsAsTaggableOn::Taggable
       tag_lists = tag_types.map {|tags_type| "#{tags_type.to_s.singularize}_list"}
       super.delete_if {|attr| tag_lists.include? attr }
     end
-    
+
     ##
     # Override this hook if you wish to subclass {ActsAsTaggableOn::Tag} --
     # context is provided so that you may conditionally use a Tag subclass

--- a/spec/acts_as_taggable_on/taggable_spec.rb
+++ b/spec/acts_as_taggable_on/taggable_spec.rb
@@ -208,6 +208,13 @@ describe 'Taggable' do
     expect(TaggableModel.tagged_with('ruby').group(:created_at).count.count).to eq(1)
   end
 
+  it 'should be able to get a count when using any' do
+    @taggable.skill_list = 'ruby'
+    @taggable.save
+
+    expect(TaggableModel.tagged_with('ruby', any: true).count).to eq(1)
+  end
+
   it 'can be used as scope' do
     @taggable.skill_list = 'ruby'
     @taggable.save


### PR DESCRIPTION
Fixes #649
ActiveRecord doesn't support the syntax Class.select('table_name.*').
