### PR TITLE
Rails 5 Compatibility

### DIFF
--- a/lib/acts_as_taggable_on/compatibility.rb
+++ b/lib/acts_as_taggable_on/compatibility.rb
@@ -1,6 +1,6 @@
 module ActsAsTaggableOn::Compatibility
   def has_many_with_taggable_compatibility(name, options = {}, &extention)
-    if ActsAsTaggableOn::Utils.active_record4?
+    if ActsAsTaggableOn::Utils.active_record_4_or_greater?
       scope, opts = build_taggable_scope_and_options(options)
       has_many(name, scope, opts, &extention)
     else

--- a/lib/acts_as_taggable_on/utils.rb
+++ b/lib/acts_as_taggable_on/utils.rb
@@ -21,7 +21,7 @@ module ActsAsTaggableOn
         Digest::SHA1.hexdigest(string)[0..6]
       end
 
-      def active_record4?
+      def active_record_4_or_greater?
         ::ActiveRecord::VERSION::MAJOR >= 4
       end
 

--- a/lib/acts_as_taggable_on/utils.rb
+++ b/lib/acts_as_taggable_on/utils.rb
@@ -22,7 +22,7 @@ module ActsAsTaggableOn
       end
 
       def active_record4?
-        ::ActiveRecord::VERSION::MAJOR == 4
+        ::ActiveRecord::VERSION::MAJOR >= 4
       end
 
       def like_operator

--- a/spec/support/database.rb
+++ b/spec/support/database.rb
@@ -15,7 +15,7 @@ if File.exist?(database_yml)
   begin
     #activerecord 4 uses symbol
     #TODO, remove when activerecord 3 support is dropped
-    if ActsAsTaggableOn::Utils.active_record4?
+    if ActsAsTaggableOn::Utils.active_record_4_or_greater?
       ActiveRecord::Base.establish_connection(db_name.to_sym)
     else
       ActiveRecord::Base.establish_connection(db_name)


### PR DESCRIPTION
The util method `active_record4?` does not account for major versions higher than `4` (like `5`).

This PR patches association/relation support for those of us on edge Rails.