### PR TITLE
References working parser in deprectation warning

### DIFF
--- a/lib/acts_as_taggable_on/tag_list_parser.rb
+++ b/lib/acts_as_taggable_on/tag_list_parser.rb
@@ -12,7 +12,7 @@ module ActsAsTaggableOn
         ActiveRecord::Base.logger.warn <<WARNING
 ActsAsTaggableOn::TagListParser.parse is deprecated \
 and will be removed from v4.0+, use  \
-ActsAsTaggableOn::TagListParser.new instead
+ActsAsTaggableOn::DefaultParser.new instead
 WARNING
         DefaultParser.new(string).parse
       end


### PR DESCRIPTION
ActsAsTaggableOn::TagListParser.new is undefined, so referencing the DefaultParser could make sense for a deprecation warning.