### PR TITLE
scope tags to specific tagging context

### DIFF
--- a/lib/acts_as_taggable_on/tag.rb
+++ b/lib/acts_as_taggable_on/tag.rb
@@ -50,6 +50,12 @@ module ActsAsTaggableOn
       where(clause)
     end
 
+    def self.for_context(context)
+      joins(:taggings).
+        where(["taggings.context = ?", context]).
+        select("DISTINCT tags.*")
+    end
+
     ### CLASS METHODS:
 
     def self.find_or_create_with_like_by_name(name)

--- a/spec/acts_as_taggable_on/tag_spec.rb
+++ b/spec/acts_as_taggable_on/tag_spec.rb
@@ -55,6 +55,21 @@ describe ActsAsTaggableOn::Tag do
     end
   end
 
+  describe 'for context' do
+    before(:each) do
+      @user.skill_list.add('ruby')
+      @user.save
+    end
+
+    it 'should return tags that have been used in the given context' do
+      expect(ActsAsTaggableOn::Tag.for_context('skills').all.map(&:name)).to include('ruby')
+    end
+
+    it 'should not return tags that have been used in other contexts' do
+      expect(ActsAsTaggableOn::Tag.for_context('needs').all.map(&:name)).to_not include('ruby')
+    end
+  end
+
   describe 'find or create by name' do
     before(:each) do
       @tag.name = 'awesome'


### PR DESCRIPTION
I found this to be pretty valuable (no need to subclass for my use case):

```ruby
ActsAsTaggableOn::Tag.for_context('skills') => # tags applied to 'skills' context, but not 'needs' context
```