### PR TITLE
Rails 5: Tagger is optional in Tagging relation.

### DIFF
--- a/lib/acts_as_taggable_on/tagging.rb
+++ b/lib/acts_as_taggable_on/tagging.rb
@@ -13,7 +13,8 @@ module ActsAsTaggableOn
 
     belongs_to :tag, class_name: '::ActsAsTaggableOn::Tag', counter_cache: ActsAsTaggableOn.tags_counter
     belongs_to :taggable, polymorphic: true
-    belongs_to :tagger,   polymorphic: true
+
+    belongs_to :tagger, {polymorphic: true}.tap {|o| o.merge!(optional: true) if ActsAsTaggableOn::Utils.active_record5? }
 
     scope :owned_by, ->(owner) { where(tagger: owner) }
     scope :not_owned, -> { where(tagger_id: nil, tagger_type: nil) }


### PR DESCRIPTION
Rails 5 automatically adds a presence validation on belongs_to associations:

* https://github.com/rails/rails/issues/18233
* http://edgeapi.rubyonrails.org/classes/ActiveRecord/Associations/ClassMethods.html#method-i-belongs_to