### PR TITLE
Update clean! method to use case insensitive uniq! when strict_case_m…

### DIFF
--- a/lib/acts_as_taggable_on/tag_list.rb
+++ b/lib/acts_as_taggable_on/tag_list.rb
@@ -84,7 +84,7 @@ module ActsAsTaggableOn
       map! { |tag| tag.mb_chars.downcase.to_s } if ActsAsTaggableOn.force_lowercase
       map!(&:parameterize) if ActsAsTaggableOn.force_parameterize
 
-      uniq!
+      ActsAsTaggableOn.strict_case_match ? uniq! : uniq!{ |tag| tag.downcase }
     end
 
 

--- a/spec/acts_as_taggable_on/tag_list_spec.rb
+++ b/spec/acts_as_taggable_on/tag_list_spec.rb
@@ -114,6 +114,20 @@ describe ActsAsTaggableOn::TagList do
 
       ActsAsTaggableOn.force_lowercase = false
     end
+
+    it 'should ignore case when removing duplicates if strict_case_match is false' do
+      tag_list = ActsAsTaggableOn::TagList.new('Junglist', 'JUNGLIST', 'Junglist', 'Massive', 'MASSIVE', 'MASSIVE')
+
+      expect(tag_list.to_s).to eq('Junglist, Massive')
+    end
+
+    it 'should not ignore case when removing duplicates if strict_case_match is true' do
+      ActsAsTaggableOn.strict_case_match = true
+      tag_list = ActsAsTaggableOn::TagList.new('Junglist', 'JUNGLIST', 'Junglist', 'Massive', 'MASSIVE', 'MASSIVE')
+
+      expect(tag_list.to_s).to eq('Junglist, JUNGLIST, Massive, MASSIVE')
+      ActsAsTaggableOn.strict_case_match = false
+    end
   end
 
   describe 'custom parser' do


### PR DESCRIPTION
…atch is false

The clean! method in tag_list.rb uses uniq! to remove duplicates from the list. When strict_case_match is false it will not remove duplicates that are the same words but differently cased.

I've changed this so that these duplicates will still be removed, so a tag_list containing ["one","One","OnE"] will become ["one"] when strict_case_match is false.