### PR TITLE
Cached Attributes (Rails 4) & marking nested models as dirty

### DIFF
--- a/lib/acts_as_taggable_on/taggable/cache.rb
+++ b/lib/acts_as_taggable_on/taggable/cache.rb
@@ -40,10 +40,25 @@ module ActsAsTaggableOn::Taggable
           end
         end
 
+        ###
+        # Clear local column cache when parent does
+        # https://github.com/jpregracke/acts-as-taggable-on/commit/92ef120b9716e392285c1617f2e6838b8da45e00
+        #
         def reset_column_information
           super
+          clear_acts_as_taggable_on_cache_columns
+        end
+
+        def clear_caches_calculated_from_columns
+          super
+          clear_acts_as_taggable_on_cache_columns
+        end
+
+        def clear_acts_as_taggable_on_cache_columns
           @acts_as_taggable_on_cache_columns = nil
         end
+        #
+        ####
       end
     end
 

--- a/lib/acts_as_taggable_on/taggable/core.rb
+++ b/lib/acts_as_taggable_on/taggable/core.rb
@@ -333,9 +333,11 @@ module ActsAsTaggableOn::Taggable
 
     def set_tag_list_on(context, new_list)
       add_custom_context(context)
-
       variable_name = "@#{context.to_s.singularize}_list"
-      process_dirty_object(context, new_list) unless custom_contexts.include?(context.to_s)
+
+      # Dirty objects require that there be an attribute defined. When using a Custom Context (spec/acts_as_taggable_on/taggable_spec.rb:466)
+      # this attribute is not defined. Set the record as Dirty on the original (defined) tag_types versus using Core#custom_contexts
+      process_dirty_object(context, new_list) if context.to_s.in?(tag_types.map(&:to_s))
 
       instance_variable_set(variable_name, ActsAsTaggableOn.default_parser.new(new_list).parse)
     end

--- a/spec/acts_as_taggable_on/acts_as_taggable_on_spec.rb
+++ b/spec/acts_as_taggable_on/acts_as_taggable_on_spec.rb
@@ -187,6 +187,18 @@ describe 'Acts As Taggable On' do
       taggable = TaggableModel.where(name: 'Dynamic Taggable').first
       expect(taggable.tagging_contexts).to eq(%w(tags languages skills needs offerings array colors))
     end
+
+    it "will not mark dynamic contexts as Dirty" do
+      taggable = TaggableModel.create!(name: 'Dynamic Taggable')
+      expect(taggable).not_to receive(:process_dirty_object)
+      taggable.set_tag_list_on :colors, 'tag1, tag2, tag3'
+    end
+
+    it "will mark object as dirty when context has been defined" do
+      taggable = TaggableModel.create!(name: 'Dynamic Taggable')
+      expect(taggable).to receive(:process_dirty_object)
+      taggable.set_tag_list_on :needs, 'tag1, tag2, tag3'
+    end
   end
 
   context 'when tagging context ends in an "s" when singular (ex. "status", "glass", etc.)' do

--- a/spec/acts_as_taggable_on/taggable_spec.rb
+++ b/spec/acts_as_taggable_on/taggable_spec.rb
@@ -468,8 +468,19 @@ describe 'Taggable' do
     bob.set_tag_list_on(:rotors, 'spinning, jumping')
     expect(bob.tag_list_on(:rotors)).to eq(%w(spinning jumping))
     bob.save
-
     expect(TaggableModel.tagged_with('spinning', on: :rotors).to_a).to eq([bob])
+  end
+
+  it "should be able to call set_tag_list_on multiple times on a custom tag context" do
+    bob = TaggableModel.create(name: 'Bob')
+    bob.set_tag_list_on(:rotors, 'spinning, jumping')
+    expect(bob.tag_list_on(:rotors)).to eq(%w(spinning jumping))
+    bob.save
+    expect(TaggableModel.tagged_with('spinning', on: :rotors).to_a).to eq([bob])
+
+    bob.set_tag_list_on(:rotors, 'spinning, jumping, climbing')
+    bob.save
+    expect(TaggableModel.tagged_with('climbing', on: :rotors).to_a).to eq([bob])
   end
 
   it 'should be able to use named scopes to chain tag finds' do


### PR DESCRIPTION
https://github.com/mbleigh/acts-as-taggable-on/issues/342
- Clear local column cache when parent does
- Get the model to be marked as dirty when setting a new list via a context

Model

``` ruby
class TaggableModel < ActiveRecord::Base
  acts_as_taggable
  acts_as_taggable_on :languages
end
```

Controller

``` ruby
class FoosController < ContentAdminController
      # .....
      def update
        if @foo.update_attributes(update_params)
          redirect_to foo_path(@foo), flash: {success: 'Updated foo.'}
        else
          render :edit
        end
      end
      # .....
    private

      def update_params
        params.require(:foo).permit(
          :taggable_attributes => [
            :id, :_destroy, {:language_list => []}
          ]
        )
      end
end
```

Post Data looks like...

``` json
{
  "utf8"=>"✓",
  "authenticity_token"=>"some-tada-here",
  "foo"=>{
    "taggable_attributes"=>{
      "0"=>{
        "_destroy"=>"0",
        "language_list"=>"english, french, german",
        "id"=>"15"
      }
    }
  },
  "commit"=>"Save",
  "id"=>"1"
}
```

Given the above, the TaggableModel will not receive a Dirty state, which ends up with an unsaved child.
