### PR TITLE
Bugfix flakey time test

### DIFF
--- a/spec/acts_as_taggable_on/taggable_spec.rb
+++ b/spec/acts_as_taggable_on/taggable_spec.rb
@@ -226,8 +226,10 @@ describe 'Taggable' do
   it "should be able to find a tag using dates" do
     @taggable.skill_list = "ruby"
     @taggable.save
+    today = Date.today.to_time.utc
+    tomorrow = Date.tomorrow.to_time.utc
 
-    expect(TaggableModel.tagged_with("ruby", :start_at => Date.today, :end_at => Date.tomorrow).count).to eq(1)
+    expect(TaggableModel.tagged_with("ruby", :start_at => today, :end_at => tomorrow).count).to eq(1)
   end
 
     it "shouldn't be able to find a tag outside date range" do


### PR DESCRIPTION
This test will fail if run on a non-UTC machine in a certain time frame.

For example, if running in EST after 7pm, the date stored in the database (which is in UTC) will be the following day (because it is 5 hours ahead -- after midnight), while the query will be for the current day.