### PR TITLE
Bugfix `TagList#concat` with non-duplicates.

### DIFF
--- a/lib/acts_as_taggable_on/tag_list.rb
+++ b/lib/acts_as_taggable_on/tag_list.rb
@@ -41,6 +41,7 @@ module ActsAsTaggableOn
     # Appends the elements of +other_tag_list+ to +self+.
     def concat(other_tag_list)
       super(other_tag_list).send(:clean!)
+      self
     end
 
     ##

--- a/spec/acts_as_taggable_on/tag_list_spec.rb
+++ b/spec/acts_as_taggable_on/tag_list_spec.rb
@@ -83,6 +83,18 @@ describe ActsAsTaggableOn::TagList do
       new_tag_list = tag_list.concat(another_tag_list)
       expect(new_tag_list.class).to eq(ActsAsTaggableOn::TagList)
     end
+
+    context 'without duplicates' do
+      let(:arr) { ['crazy', 'alien'] }
+      let(:another_tag_list) { ActsAsTaggableOn::TagList.new(*arr) }
+      it 'adds other list' do
+        expect(tag_list.concat(another_tag_list)).to eq(%w[awesome radical crazy alien])
+      end
+
+      it 'adds other array' do
+        expect(tag_list.concat(arr)).to eq(%w[awesome radical crazy alien])
+      end
+    end
   end
 
   describe '#to_s' do


### PR DESCRIPTION
`uniq!` behaves differently depending on whether duplicates are found or not: if they are, the de-duped list is returned, otherwise `nil` is returned.
