### PR TITLE
Tag ordering setting the default ordering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ As such, a _Feature_ would map to either major or minor. A _bug fix_ to a patch.
 
   * Fixes
    * [@rikettsie Fixed collation for MySql via rake rule or config parameter](https://github.com/mbleigh/acts-as-taggable-on/pull/634)
+  *Misc
+   * [@pcupueran Add rspec test for tagging_spec]()
 
 ### [3.4.4 / 2015-02-11](https://github.com/mbleigh/acts-as-taggable-on/compare/v3.4.3...v3.4.4)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,6 @@ As such, a _Feature_ would map to either major or minor. A _bug fix_ to a patch.
 
   * Fixes
    * [@rikettsie Fixed collation for MySql via rake rule or config parameter](https://github.com/mbleigh/acts-as-taggable-on/pull/634)
-  *Misc
-   * [@pcupueran Add rspec test for tagging_spec]()
 
   *Features
    * [@pcupueran Allow to set the default ordering to order tags]()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ As such, a _Feature_ would map to either major or minor. A _bug fix_ to a patch.
   *Misc
    * [@pcupueran Add rspec test for tagging_spec]()
 
+  *Features
+   * [@pcupueran Allow to set the default ordering to order tags]()
+
 ### [3.4.4 / 2015-02-11](https://github.com/mbleigh/acts-as-taggable-on/compare/v3.4.3...v3.4.4)
 
   * Fixes

--- a/lib/acts_as_taggable_on/tag.rb
+++ b/lib/acts_as_taggable_on/tag.rb
@@ -22,7 +22,7 @@ module ActsAsTaggableOn
     ### SCOPES:
     scope :most_used, ->(limit = 20) { order('taggings_count desc').limit(limit) }
     scope :least_used, ->(limit = 20) { order('taggings_count asc').limit(limit) }
-    scope :default_ordering, ->(sort = TaggableModel.default_ordering) { order(sort)}
+    scope :default_ordering, ->(sort = TaggableModel.default_ordering) { order(sort) }
 
     def self.named(name)
       if ActsAsTaggableOn.strict_case_match

--- a/lib/acts_as_taggable_on/tag.rb
+++ b/lib/acts_as_taggable_on/tag.rb
@@ -22,6 +22,7 @@ module ActsAsTaggableOn
     ### SCOPES:
     scope :most_used, ->(limit = 20) { order('taggings_count desc').limit(limit) }
     scope :least_used, ->(limit = 20) { order('taggings_count asc').limit(limit) }
+    scope :default_ordering, ->(sort = TaggableModel.default_ordering) { order(sort)}
 
     def self.named(name)
       if ActsAsTaggableOn.strict_case_match

--- a/lib/acts_as_taggable_on/taggable/ownership.rb
+++ b/lib/acts_as_taggable_on/taggable/ownership.rb
@@ -39,7 +39,7 @@ module ActsAsTaggableOn::Taggable
       # when preserving tag order, return tags in created order
       # if we added the order to the association this would always apply
       if self.class.preserve_tag_order?
-        scope.order("#{ActsAsTaggableOn::Tagging.table_name}.id")
+        scope.order(self.class.default_ordering)
       else
         scope
       end

--- a/spec/acts_as_taggable_on/single_table_inheritance_spec.rb
+++ b/spec/acts_as_taggable_on/single_table_inheritance_spec.rb
@@ -175,6 +175,15 @@ describe 'Single Table Inheritance' do
       expect(taggable.owner_tags_on(student, :tags).count).to eq(2)
     end
 
+    it "returns owner tags on the tagger ordered by the default ordering in which the tags were created" do
+      student.tag(taggable, with: 'ruby, python, java', on: :languages)
+
+      expect(taggable.owner_tags_on(student, :languages).default_ordering.count).to eq(3)
+      expect(taggable.owner_tags_on(student, :languages).default_ordering.first.name).to eq("ruby")
+      expect(taggable.owner_tags_on(student, :languages).default_ordering.second.name).to eq("python")
+      expect(taggable.owner_tags_on(student, :languages).default_ordering.third.name).to eq("java")
+    end
+
     it 'should scope objects returned by tagged_with by owners' do
       student.tag(taggable, with: 'ruby, scheme', on: :tags)
       expect(TaggableModel.tagged_with(%w(ruby scheme), owned_by: student).count).to eq(1)

--- a/spec/acts_as_taggable_on/single_table_inheritance_spec.rb
+++ b/spec/acts_as_taggable_on/single_table_inheritance_spec.rb
@@ -184,6 +184,32 @@ describe 'Single Table Inheritance' do
       expect(taggable.owner_tags_on(student, :languages).default_ordering.third.name).to eq("java")
     end
 
+    it "returns owner tags on the tagger ordered by default ordering equals to name" do
+      student.tag(taggable, with: 'ruby, python, java', on: :languages)
+
+      taggable.class.default_ordering = :name
+
+      expect(taggable.owner_tags_on(student, :languages).count).to eq(3)
+      expect(taggable.owner_tags_on(student, :languages).default_ordering.first.name).to eq("java")
+      expect(taggable.owner_tags_on(student, :languages).default_ordering.second.name).to eq("python")
+      expect(taggable.owner_tags_on(student, :languages).default_ordering.third.name).to eq("ruby")
+    end
+
+    it "returns owner tags on the tagger ordered by default ordering equals to taggings_count desc" do
+      student.tag(taggable, with: 'ruby, java, python', on: :languages)
+      student.tag(taggable, with: 'ruby, python', on: :technologies)
+      student.tag(taggable, with: 'ruby', on: :object_oriented)
+
+      taggable.class.default_ordering = "taggings_count desc"
+      expect(taggable.owner_tags_on(student, :languages).count).to eq(3)
+      expect(taggable.owner_tags_on(student, :languages).default_ordering.first.name).to eq("ruby")
+      expect(taggable.owner_tags_on(student, :languages).default_ordering.first.taggings_count).to eq(3)
+      expect(taggable.owner_tags_on(student, :languages).default_ordering.second.name).to eq("python")
+      expect(taggable.owner_tags_on(student, :languages).default_ordering.second.taggings_count).to eq(2)
+      expect(taggable.owner_tags_on(student, :languages).default_ordering.third.name).to eq("java")
+      expect(taggable.owner_tags_on(student, :languages).default_ordering.third.taggings_count).to eq(1)
+    end
+
     it 'should scope objects returned by tagged_with by owners' do
       student.tag(taggable, with: 'ruby, scheme', on: :tags)
       expect(TaggableModel.tagged_with(%w(ruby scheme), owned_by: student).count).to eq(1)

--- a/spec/acts_as_taggable_on/tagging_spec.rb
+++ b/spec/acts_as_taggable_on/tagging_spec.rb
@@ -49,12 +49,37 @@ describe ActsAsTaggableOn::Tagging do
     ActsAsTaggableOn.remove_unused_tags = previous_setting
   end
 
+  describe '.owned_by' do
+    before do
+      @tagging_2 = ActsAsTaggableOn::Tagging.new
+      @tagger = ActsAsTaggableOn::Tagger.new
+      @tagger_2 = ActsAsTaggableOn::Tagger.new
+    end
+
+    it "should belong to a specific user" do
+      @tagging.taggable = TaggableModel.create(name: "Black holes")
+      @tagging.tag = ActsAsTaggableOn::Tag.new("Physics")
+      @tagging.tagger = @tagger
+      @tagging.context = 'Science'
+
+      @tagging_2.taggable = TaggableModel.create(name: "Satellites")
+
+      @tagging_2.tag = ActsAsTaggableOn::Tag.new("Astronomy")
+      @tagging_2.tag = ActsAsTaggableOn::Tag.new("Physics")
+      @tagging_2.tagger = @tagger_2
+      @tagging_2.context = 'Science'
+
+      expect(@tagging.owned_by).to eq(@tagger)
+      expect(@tagging_2.owned_by).to eq(@tagger_2)
+    end
+
+  end
+
   pending 'context scopes' do
     describe '.by_context'
 
     describe '.by_contexts'
 
-    describe '.owned_by'
 
     describe '.not_owned'
 

--- a/spec/acts_as_taggable_on/tagging_spec.rb
+++ b/spec/acts_as_taggable_on/tagging_spec.rb
@@ -49,74 +49,15 @@ describe ActsAsTaggableOn::Tagging do
     ActsAsTaggableOn.remove_unused_tags = previous_setting
   end
 
-  describe 'context scopes' do
-    before do
-      @tagging_2 = ActsAsTaggableOn::Tagging.new
-      @tagging_3 = ActsAsTaggableOn::Tagging.new
+  pending 'context scopes' do
+    describe '.by_context'
 
-      @tagger = User.new
-      @tagger_2 = User.new
+    describe '.by_contexts'
 
-      @tagging.taggable = TaggableModel.create(name: "Black holes")
-      @tagging.tag = ActsAsTaggableOn::Tag.create(name: "Physics")
-      @tagging.tagger = @tagger
-      @tagging.context = 'Science'
-      @tagging.save
+    describe '.owned_by'
 
-      @tagging_2.taggable = TaggableModel.create(name: "Satellites")
-      @tagging_2.tag = ActsAsTaggableOn::Tag.create(name: "Technology")
-      @tagging_2.tagger = @tagger_2
-      @tagging_2.context = 'Science'
-      @tagging_2.save
+    describe '.not_owned'
 
-      @tagging_3.taggable = TaggableModel.create(name: "Satellites")
-      @tagging_3.tag = ActsAsTaggableOn::Tag.create(name: "Engineering")
-      @tagging_3.tagger = @tagger_2
-      @tagging_3.context = 'Astronomy'
-      @tagging_3.save
-
-    end
-
-    describe '.owned_by' do
-      it "should belong to a specific user" do
-        expect(@tagging).to be_valid
-        expect(@tagging_2).to be_valid
-
-        expect(ActsAsTaggableOn::Tagging.owned_by(@tagger).first).to eq(@tagging)
-        expect(ActsAsTaggableOn::Tagging.owned_by(@tagger_2).first).to eq(@tagging_2)
-      end
-    end
-
-    describe '.by_context' do
-      it "should be found by context" do
-        expect(ActsAsTaggableOn::Tagging.by_context('Science').length).to eq(2);
-      end
-    end
-
-    describe '.by_contexts' do
-      it "should find taggings by contexts" do
-        expect(@tagging_3).to be_valid
-        expect(ActsAsTaggableOn::Tagging.by_contexts(['Science', 'Astronomy']).first).to eq(@tagging);
-        expect(ActsAsTaggableOn::Tagging.by_contexts(['Science', 'Astronomy']).second).to eq(@tagging_2);
-        expect(ActsAsTaggableOn::Tagging.by_contexts(['Science', 'Astronomy']).third).to eq(@tagging_3);
-        expect(ActsAsTaggableOn::Tagging.by_contexts(['Science', 'Astronomy']).length).to eq(3);
-      end
-    end
-
-    describe '.not_owned' do
-      before do
-        @tagging_4 = ActsAsTaggableOn::Tagging.new
-        @tagging_4.taggable = TaggableModel.create(name: "Gravity")
-        @tagging_4.tag = ActsAsTaggableOn::Tag.create(name: "Space")
-        @tagging_4.context = "Science"
-        @tagging_4.save
-      end
-
-      it "should found the taggings that do not have owner" do
-        expect(ActsAsTaggableOn::Tagging.all.length).to eq(4)
-        expect(ActsAsTaggableOn::Tagging.not_owned.length).to eq(1)
-        expect(ActsAsTaggableOn::Tagging.not_owned.first).to eq(@tagging_4)
-      end
-    end
   end
+
 end

--- a/spec/acts_as_taggable_on/tagging_spec.rb
+++ b/spec/acts_as_taggable_on/tagging_spec.rb
@@ -52,6 +52,7 @@ describe ActsAsTaggableOn::Tagging do
   describe 'context scopes' do
     before do
       @tagging_2 = ActsAsTaggableOn::Tagging.new
+      @tagging_3 = ActsAsTaggableOn::Tagging.new
 
       @tagger = User.new
       @tagger_2 = User.new
@@ -67,6 +68,13 @@ describe ActsAsTaggableOn::Tagging do
       @tagging_2.tagger = @tagger_2
       @tagging_2.context = 'Science'
       @tagging_2.save
+
+      @tagging_3.taggable = TaggableModel.create(name: "Satellites")
+      @tagging_3.tag = ActsAsTaggableOn::Tag.create(name: "Engineering")
+      @tagging_3.tagger = @tagger_2
+      @tagging_3.context = 'Astronomy'
+      @tagging_3.save
+
     end
 
     describe '.owned_by' do
@@ -84,15 +92,20 @@ describe ActsAsTaggableOn::Tagging do
         expect(ActsAsTaggableOn::Tagging.by_context('Science').length).to eq(2);
       end
     end
+
+    describe '.by_contexts' do
+      it "should find taggings by contexts" do
+        expect(@tagging_3).to be_valid
+        expect(ActsAsTaggableOn::Tagging.by_contexts(['Science', 'Astronomy']).first).to eq(@tagging);
+        expect(ActsAsTaggableOn::Tagging.by_contexts(['Science', 'Astronomy']).second).to eq(@tagging_2);
+        expect(ActsAsTaggableOn::Tagging.by_contexts(['Science', 'Astronomy']).third).to eq(@tagging_3);
+        expect(ActsAsTaggableOn::Tagging.by_contexts(['Science', 'Astronomy']).length).to eq(3);
+      end
+    end
   end
 
   pending 'context scopes' do
-
-
-    describe '.by_contexts'
-
     describe '.not_owned'
-
   end
 
 end

--- a/spec/acts_as_taggable_on/tagging_spec.rb
+++ b/spec/acts_as_taggable_on/tagging_spec.rb
@@ -78,11 +78,16 @@ describe ActsAsTaggableOn::Tagging do
         expect(ActsAsTaggableOn::Tagging.owned_by(@tagger_2).first).to eq(@tagging_2)
       end
     end
+
+    describe '.by_context' do
+      it "should be found by context" do
+        expect(ActsAsTaggableOn::Tagging.by_context('Science').length).to eq(2);
+      end
+    end
   end
 
   pending 'context scopes' do
 
-    describe '.by_context'
 
     describe '.by_contexts'
 

--- a/spec/acts_as_taggable_on/tagging_spec.rb
+++ b/spec/acts_as_taggable_on/tagging_spec.rb
@@ -49,37 +49,42 @@ describe ActsAsTaggableOn::Tagging do
     ActsAsTaggableOn.remove_unused_tags = previous_setting
   end
 
-  describe '.owned_by' do
+  describe 'context scopes' do
     before do
       @tagging_2 = ActsAsTaggableOn::Tagging.new
-      @tagger = ActsAsTaggableOn::Tagger.new
-      @tagger_2 = ActsAsTaggableOn::Tagger.new
-    end
 
-    it "should belong to a specific user" do
+      @tagger = User.new
+      @tagger_2 = User.new
+
       @tagging.taggable = TaggableModel.create(name: "Black holes")
-      @tagging.tag = ActsAsTaggableOn::Tag.new("Physics")
+      @tagging.tag = ActsAsTaggableOn::Tag.create(name: "Physics")
       @tagging.tagger = @tagger
       @tagging.context = 'Science'
+      @tagging.save
 
       @tagging_2.taggable = TaggableModel.create(name: "Satellites")
-
-      @tagging_2.tag = ActsAsTaggableOn::Tag.new("Astronomy")
-      @tagging_2.tag = ActsAsTaggableOn::Tag.new("Physics")
+      @tagging_2.tag = ActsAsTaggableOn::Tag.create(name: "Technology")
       @tagging_2.tagger = @tagger_2
       @tagging_2.context = 'Science'
-
-      expect(@tagging.owned_by).to eq(@tagger)
-      expect(@tagging_2.owned_by).to eq(@tagger_2)
+      @tagging_2.save
     end
 
+    describe '.owned_by' do
+      it "should belong to a specific user" do
+        expect(@tagging).to be_valid
+        expect(@tagging_2).to be_valid
+
+        expect(ActsAsTaggableOn::Tagging.owned_by(@tagger).first).to eq(@tagging)
+        expect(ActsAsTaggableOn::Tagging.owned_by(@tagger_2).first).to eq(@tagging_2)
+      end
+    end
   end
 
   pending 'context scopes' do
+
     describe '.by_context'
 
     describe '.by_contexts'
-
 
     describe '.not_owned'
 

--- a/spec/acts_as_taggable_on/tagging_spec.rb
+++ b/spec/acts_as_taggable_on/tagging_spec.rb
@@ -102,10 +102,21 @@ describe ActsAsTaggableOn::Tagging do
         expect(ActsAsTaggableOn::Tagging.by_contexts(['Science', 'Astronomy']).length).to eq(3);
       end
     end
-  end
 
-  pending 'context scopes' do
-    describe '.not_owned'
-  end
+    describe '.not_owned' do
+      before do
+        @tagging_4 = ActsAsTaggableOn::Tagging.new
+        @tagging_4.taggable = TaggableModel.create(name: "Gravity")
+        @tagging_4.tag = ActsAsTaggableOn::Tag.create(name: "Space")
+        @tagging_4.context = "Science"
+        @tagging_4.save
+      end
 
+      it "should found the taggings that do not have owner" do
+        expect(ActsAsTaggableOn::Tagging.all.length).to eq(4)
+        expect(ActsAsTaggableOn::Tagging.not_owned.length).to eq(1)
+        expect(ActsAsTaggableOn::Tagging.not_owned.first).to eq(@tagging_4)
+      end
+    end
+  end
 end

--- a/spec/internal/app/models/models.rb
+++ b/spec/internal/app/models/models.rb
@@ -7,6 +7,12 @@ class TaggableModel < ActiveRecord::Base
 
   attr_reader :tag_list_submethod_called
 
+  class << self
+    attr_accessor :default_ordering
+  end
+
+  @default_ordering = "#{ActsAsTaggableOn::Tagging.table_name}.id"
+
   def tag_list=(v)
     @tag_list_submethod_called = true
     super
@@ -75,6 +81,12 @@ end
 class OrderedTaggableModel < ActiveRecord::Base
   acts_as_ordered_taggable
   acts_as_ordered_taggable_on :colours
+
+  class << self
+    attr_accessor :default_ordering
+  end
+
+  @default_ordering = "#{ActsAsTaggableOn::Tagging.table_name}.id"
 end
 
 if using_postgresql?


### PR DESCRIPTION
It allows ordering tags by name or by the taggings_counts. This gives the possibility to order by other criteria than the order of tag creation.
