### PR TITLE
Remove existing selects from relation

### DIFF
--- a/lib/acts_as_taggable_on/taggable/collection.rb
+++ b/lib/acts_as_taggable_on/taggable/collection.rb
@@ -138,7 +138,7 @@ module ActsAsTaggableOn::Taggable
           scoped_ids = pluck(table_name_pkey)
           tagging_scope = tagging_scope.where("#{ActsAsTaggableOn::Tagging.table_name}.taggable_id IN (?)", scoped_ids)
         else
-          tagging_scope = tagging_scope.where("#{ActsAsTaggableOn::Tagging.table_name}.taggable_id IN(#{safe_to_sql(select(table_name_pkey))})")
+          tagging_scope = tagging_scope.where("#{ActsAsTaggableOn::Tagging.table_name}.taggable_id IN(#{safe_to_sql(except(:select).select(table_name_pkey))})")
         end
 
         tagging_scope

--- a/spec/acts_as_taggable_on/taggable_spec.rb
+++ b/spec/acts_as_taggable_on/taggable_spec.rb
@@ -119,6 +119,21 @@ describe 'Taggable' do
     expect(@taggable.tag_counts_on(:tags).length).to eq(2)
   end
 
+  context 'tag_counts on a collection' do
+    context 'a select clause is specified on the collection' do
+      it 'should return tag counts without raising an error' do
+        expect(TaggableModel.tag_counts_on(:tags)).to be_empty
+
+        @taggable.tag_list = %w(awesome epic)
+        @taggable.save
+
+        expect {
+          expect(TaggableModel.select(:name).tag_counts_on(:tags).length).to eq(2)
+        }.not_to raise_error
+      end
+    end
+  end
+
   it 'should have tags_on' do
     expect(TaggableModel.tags_on(:tags)).to be_empty
 


### PR DESCRIPTION
If there are existing, non-standard selects on a relation, the primary key sub-select will fail because it will include them as well as the primary key, which results in too many columns being present in the results.

This change removes any existing select clauses before applying the selection on the primary key.