### PR TITLE
Always process dirty objects

### DIFF
--- a/lib/acts_as_taggable_on/taggable/core.rb
+++ b/lib/acts_as_taggable_on/taggable/core.rb
@@ -335,7 +335,7 @@ module ActsAsTaggableOn::Taggable
       add_custom_context(context)
 
       variable_name = "@#{context.to_s.singularize}_list"
-      process_dirty_object(context, new_list) unless custom_contexts.include?(context.to_s)
+      process_dirty_object(context, new_list)
 
       instance_variable_set(variable_name, ActsAsTaggableOn.default_parser.new(new_list).parse)
     end


### PR DESCRIPTION
I encountered a strange behavior with models using the default "tags" context.

Without this fix, dirty fields were not reported in object changes when we update its tag list.