### PR TITLE
Fix rails 5.0.0.beta3 deprecation warning on destroy_all

### DIFF
--- a/lib/acts_as_taggable_on/taggable/core.rb
+++ b/lib/acts_as_taggable_on/taggable/core.rb
@@ -415,7 +415,7 @@ module ActsAsTaggableOn::Taggable
 
         # Destroy old taggings:
         if old_tags.present?
-          taggings.not_owned.by_context(context).destroy_all(tag_id: old_tags)
+          taggings.not_owned.by_context(context).where(tag_id: old_tags).destroy_all
         end
 
         # Create new taggings:


### PR DESCRIPTION
Rails 5.0.0.beta3 gives the following deprecation message: `DEPRECATION WARNING: Passing conditions to destroy_all is deprecated and will be removed in Rails 5.1. To achieve the same use where(conditions).destroy_all.`. This PR fixes it as suggested.