### PR TITLE
Preserve tags on destroy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ As such, a _Feature_ would map to either major or minor. A _bug fix_ to a patch.
    * [@rikettsie Fixed collation for MySql via rake rule or config parameter](https://github.com/mbleigh/acts-as-taggable-on/pull/634)
   *Misc
    * [@pcupueran Add rspec test for tagging_spec completeness]()
+  * Features
+   * [@dennis-ba Add ability to preserve tags on destroy of associated model]()
 
 ### [3.4.4 / 2015-02-11](https://github.com/mbleigh/acts-as-taggable-on/compare/v3.4.3...v3.4.4)
 

--- a/lib/acts-as-taggable-on.rb
+++ b/lib/acts-as-taggable-on.rb
@@ -59,7 +59,7 @@ module ActsAsTaggableOn
   class Configuration
     attr_accessor :force_lowercase, :force_parameterize,
                   :remove_unused_tags, :default_parser,
-                  :tags_counter
+                  :tags_counter, :preserve_tags_on_destroy
     attr_reader :delimiter, :strict_case_match
 
     def initialize
@@ -68,6 +68,7 @@ module ActsAsTaggableOn
       @force_parameterize = false
       @strict_case_match = false
       @remove_unused_tags = false
+      @preserve_tags_on_destroy = false
       @tags_counter = true
       @default_parser = DefaultParser
       @force_binary_collation = false

--- a/lib/acts_as_taggable_on/taggable.rb
+++ b/lib/acts_as_taggable_on/taggable.rb
@@ -80,7 +80,12 @@ module ActsAsTaggableOn
         self.preserve_tag_order = preserve_tag_order
 
         class_eval do
-          has_many :taggings, as: :taggable, dependent: :destroy, class_name: '::ActsAsTaggableOn::Tagging'
+          options = {as: :taggable, class_name: '::ActsAsTaggableOn::Tagging'}
+          unless ActsAsTaggableOn.preserve_tags_on_destroy
+            options[:dependent] = :destroy
+          end
+
+          has_many :taggings, options
           has_many :base_tags, through: :taggings, source: :tag, class_name: '::ActsAsTaggableOn::Tag'
 
           def self.taggable?

--- a/lib/acts_as_taggable_on/taggable/core.rb
+++ b/lib/acts_as_taggable_on/taggable/core.rb
@@ -23,18 +23,21 @@ module ActsAsTaggableOn::Taggable
           class_eval do
             # when preserving tag order, include order option so that for a 'tags' context
             # the associations tag_taggings & tags are always returned in created order
-            has_many_with_taggable_compatibility context_taggings, as: :taggable,
-                                                 dependent: :destroy,
-                                                 class_name: 'ActsAsTaggableOn::Tagging',
-                                                 order: taggings_order,
-                                                 conditions: {context: tags_type},
-                                                 include: :tag
+            options = {as: :taggable,
+                       class_name: 'ActsAsTaggableOn::Tagging',
+                       order: taggings_order,
+                       conditions: {context: tags_type},
+                       include: :tag}
+            unless ActsAsTaggableOn.preserve_tags_on_destroy
+              options[:dependent] = :destroy
+            end
+
+            has_many_with_taggable_compatibility context_taggings, options
 
             has_many_with_taggable_compatibility context_tags, through: context_taggings,
                                                  source: :tag,
                                                  class_name: 'ActsAsTaggableOn::Tag',
                                                  order: taggings_order
-
           end
 
           taggable_mixin.class_eval <<-RUBY, __FILE__, __LINE__ + 1


### PR DESCRIPTION
https://github.com/mbleigh/acts-as-taggable-on/issues/662

I have a case where I need to do a "soft delete" of database records and preserve the tags that are associated. I just need to prevent the destroy callbacks from getting created. 

I've created a new configuration parameter called preserve_tags_on_destroy that is defaulted to false.
Setting this to true removes the destroy callbacks from has_many taggings and context_taggings associations in taggable.rb and core.rb. 
