### PR TITLE
Specify Tag table name for mysql collation query

### DIFF
--- a/lib/acts-as-taggable-on.rb
+++ b/lib/acts-as-taggable-on.rb
@@ -104,7 +104,7 @@ WARNING
         coll = 'utf8_general_ci'
         coll = 'utf8_bin' if bincoll
         begin
-          ActiveRecord::Migration.execute("ALTER TABLE tags MODIFY name varchar(255) CHARACTER SET utf8 COLLATE #{coll};")
+          ActiveRecord::Migration.execute("ALTER TABLE #{Tag.table_name} MODIFY name varchar(255) CHARACTER SET utf8 COLLATE #{coll};")
         rescue Exception => e
           puts "Trapping #{e.class}: collation parameter ignored while migrating for the first time."
         end


### PR DESCRIPTION
If the tags table name is changed then mysql collation query raises exception for `tags` table not found.

Fix: Use `Tag.table_name` instead calling table name `tags` directly.