### PR TITLE
Use where before destroy_all to fix Rails 5.0.0.rc deprecations

### DIFF
--- a/lib/acts_as_taggable_on/taggable/core.rb
+++ b/lib/acts_as_taggable_on/taggable/core.rb
@@ -415,7 +415,7 @@ module ActsAsTaggableOn::Taggable
 
         # Destroy old taggings:
         if old_tags.present?
-          taggings.not_owned.by_context(context).destroy_all(tag_id: old_tags)
+          taggings.not_owned.by_context(context).where(tag_id: old_tags).destroy_all
         end
 
         # Create new taggings:

--- a/lib/acts_as_taggable_on/taggable/ownership.rb
+++ b/lib/acts_as_taggable_on/taggable/ownership.rb
@@ -108,9 +108,9 @@ module ActsAsTaggableOn::Taggable
 
           # Find all taggings that belong to the taggable (self), are owned by the owner,
           # have the correct context, and are removed from the list.
-          ActsAsTaggableOn::Tagging.destroy_all(taggable_id: id, taggable_type: self.class.base_class.to_s,
-                                                            tagger_type: owner.class.base_class.to_s, tagger_id: owner.id,
-                                                            tag_id: old_tags, context: context) if old_tags.present?
+          ActsAsTaggableOn::Tagging.where(taggable_id: id, taggable_type: self.class.base_class.to_s,
+                                                      tagger_type: owner.class.base_class.to_s, tagger_id: owner.id,
+                                                      tag_id: old_tags, context: context).destroy_all if old_tags.present?
 
           # Create new taggings:
           new_tags.each do |tag|


### PR DESCRIPTION
Passing conditions to destroy_all is deprecated and will be removed in
Rails 5.1. To achieve the same use where(conditions).destroy_all.