### PR TITLE
Given a resource: get all tags by owner and get owner tags for multiple contexts

### DIFF
--- a/lib/acts_as_taggable_on/taggable/ownership.rb
+++ b/lib/acts_as_taggable_on/taggable/ownership.rb
@@ -27,13 +27,16 @@ module ActsAsTaggableOn::Taggable
       end
     end
 
-    def owner_tags_on(owner, context)
+    def owner_tags(owner)
       if owner.nil?
-        scope = base_tags.where([%(#{ActsAsTaggableOn::Tagging.table_name}.context = ?), context.to_s])
+        scope = base_tags
       else
-        scope = base_tags.where([%(#{ActsAsTaggableOn::Tagging.table_name}.context = ? AND
-                                    #{ActsAsTaggableOn::Tagging.table_name}.tagger_id = ? AND
-                                    #{ActsAsTaggableOn::Tagging.table_name}.tagger_type = ?), context.to_s, owner.id, owner.class.base_class.to_s])
+        scope = base_tags.where(
+          "#{ActsAsTaggableOn::Tagging.table_name}" => {
+            tagger_id: owner.id,
+            tagger_type: owner.class.base_class.to_s
+          }
+        )
       end
 
       # when preserving tag order, return tags in created order
@@ -43,6 +46,10 @@ module ActsAsTaggableOn::Taggable
       else
         scope
       end
+    end
+
+    def owner_tags_on(owner, context)
+      scope = owner_tags(owner).where([%(#{ActsAsTaggableOn::Tagging.table_name}.context = ?), context.to_s])      
     end
 
     def cached_owned_tag_list_on(context)

--- a/lib/acts_as_taggable_on/taggable/ownership.rb
+++ b/lib/acts_as_taggable_on/taggable/ownership.rb
@@ -49,7 +49,11 @@ module ActsAsTaggableOn::Taggable
     end
 
     def owner_tags_on(owner, context)
-      scope = owner_tags(owner).where([%(#{ActsAsTaggableOn::Tagging.table_name}.context = ?), context.to_s])      
+      scope = owner_tags(owner).where(
+        "#{ActsAsTaggableOn::Tagging.table_name}" => {
+          context: context
+        }
+      )
     end
 
     def cached_owned_tag_list_on(context)

--- a/spec/acts_as_taggable_on/single_table_inheritance_spec.rb
+++ b/spec/acts_as_taggable_on/single_table_inheritance_spec.rb
@@ -170,9 +170,25 @@ describe 'Single Table Inheritance' do
       expect(taggable.tags_from(student)).to eq(%w(ruby scheme))
     end
 
+    it 'returns all owner tags on the taggable' do
+      student.tag(taggable, with: 'ruby, scheme', on: :tags)
+      student.tag(taggable, with: 'skill_one', on: :skills)
+      student.tag(taggable, with: 'english, spanish', on: :language)
+      expect(taggable.owner_tags(student).count).to eq(5)
+      expect(taggable.owner_tags(student).sort == %w(english ruby scheme skill_one spanish))
+    end
+
+
     it 'returns owner tags on the tagger' do
       student.tag(taggable, with: 'ruby, scheme', on: :tags)
       expect(taggable.owner_tags_on(student, :tags).count).to eq(2)
+    end
+
+    it 'returns owner tags on the taggable for an array of contexts' do
+      student.tag(taggable, with: 'ruby, scheme', on: :tags)
+      student.tag(taggable, with: 'skill_one, skill_two', on: :skills)
+      expect(taggable.owner_tags_on(student, [:tags, :skills]).count).to eq(4)
+      expect(taggable.owner_tags_on(student, [:tags, :skills]).sort == %w(ruby scheme skill_one skill_two))
     end
 
     it 'should scope objects returned by tagged_with by owners' do
@@ -208,4 +224,3 @@ describe 'Single Table Inheritance' do
     end
   end
 end
-


### PR DESCRIPTION
This allows to
- Retrieve all the tags to a resource by an owner in one go
- Retrieve owner tags by multiple context in one go
