### PR TITLE
add foreign key support for tagging to tags

### DIFF
--- a/db/migrate/7_add_tag_foreign_key.rb
+++ b/db/migrate/7_add_tag_foreign_key.rb
@@ -1,0 +1,5 @@
+class AddTagForeignKey < ActiveRecord::Migration
+  def change
+    add_foreign_key :taggings, :tags, column: :tag_id
+  end
+end


### PR DESCRIPTION
Was looking at the migrations and noticed that there was no foreign key added for referential integrity. For Rails 4.2 and 5 users, this a nice addition.

For performance, we could also look at adding `on_delete: :cascade` as well. Thoughts?
