### PR TITLE
Rename migration to avoid conflicts

### DIFF
--- a/db/migrate/6_add_missing_indexes_on_taggings.rb
+++ b/db/migrate/6_add_missing_indexes_on_taggings.rb
@@ -1,4 +1,4 @@
-class AddMissingIndexes < ActiveRecord::Migration
+class AddMissingIndexesOnTaggings < ActiveRecord::Migration
   def change
     add_index :taggings, :tag_id
     add_index :taggings, :taggable_id


### PR DESCRIPTION
The AddMissingIndexes migration conflicts with migrations in other
gem(s), eg spree 3.1. The name has been made more specific to avoid
such conflicts.

Fixes issue #773 