### PR TITLE
Guard against indexes already existing

### DIFF
--- a/db/migrate/6_add_missing_indexes_on_taggings.rb
+++ b/db/migrate/6_add_missing_indexes_on_taggings.rb
@@ -1,12 +1,17 @@
 class AddMissingIndexesOnTaggings < ActiveRecord::Migration
   def change
-    add_index :taggings, :tag_id
-    add_index :taggings, :taggable_id
-    add_index :taggings, :taggable_type
-    add_index :taggings, :tagger_id
-    add_index :taggings, :context
+    add_index :taggings, :tag_id unless index_exists? :taggings, :tag_id
+    add_index :taggings, :taggable_id unless index_exists? :taggings, :taggable_id
+    add_index :taggings, :taggable_type unless index_exists? :taggings, :taggable_type
+    add_index :taggings, :tagger_id unless index_exists? :taggings, :tagger_id
+    add_index :taggings, :context unless index_exists? :taggings, :context
 
-    add_index :taggings, [:tagger_id, :tagger_type]
-    add_index :taggings, [:taggable_id, :taggable_type, :tagger_id, :context], name: 'taggings_idy'
+    unless index_exists? :taggings, [:tagger_id, :tagger_type]
+      add_index :taggings, [:tagger_id, :tagger_type]
+    end
+
+    unless index_exists? :taggings, [:taggable_id, :taggable_type, :tagger_id, :context], name: 'taggings_idy'
+      add_index :taggings, [:taggable_id, :taggable_type, :tagger_id, :context], name: 'taggings_idy'
+    end
   end
 end


### PR DESCRIPTION
Since the name of a migration file was recently changed to avoid
conflicts, it will be copied over and run again. Thus, it will now be
checked if the index already exists and will be created only if that's
not the case.

Refer #774 