### PR TITLE
Reverse check order before adding custom contexts

### DIFF
--- a/lib/acts_as_taggable_on/taggable/core.rb
+++ b/lib/acts_as_taggable_on/taggable/core.rb
@@ -267,7 +267,7 @@ module ActsAsTaggableOn::Taggable
     end
 
     def add_custom_context(value)
-      custom_contexts << value.to_s unless custom_contexts.include?(value.to_s) or self.class.tag_types.map(&:to_s).include?(value.to_s)
+      custom_contexts << value.to_s unless self.class.tag_types.map(&:to_s).include?(value.to_s) or custom_contexts.include?(value.to_s)
     end
 
     def cached_tag_list_on(context)


### PR DESCRIPTION
Reversing this order allows the process to move forward without loading
the `taggings` relationship when a context has already been defined for
the model.

This helps when a model is using a `cached_#{context.to_s.singular}_list`
column and the `taggings` are NOT being eager loaded. It can save a lot
of unexpected N+1 cases.
