### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,7 @@ User.tagged_with("awesome").by_join_date
 User.tagged_with("awesome").by_join_date.paginate(:page => params[:page], :per_page => 20)
 
 # Find users that matches all given tags:
+# NOTE: This only matches users that have the exact set of specified tags. If a user has additional tags, they are not returned.
 User.tagged_with(["awesome", "cool"], :match_all => true)
 
 # Find users with any of the specified tags:


### PR DESCRIPTION
Clarify that the :match_all option specifies an exact set of tags to search for. Any object instance with additional tags is not returned.