### PR TITLE
Fix `caching_tag_list_on?` bug (#432)

### DIFF
--- a/lib/acts_as_taggable_on/taggable/core.rb
+++ b/lib/acts_as_taggable_on/taggable/core.rb
@@ -275,7 +275,7 @@ module ActsAsTaggableOn::Taggable
       variable_name = "@#{context.to_s.singularize}_list"
       if instance_variable_get(variable_name)
         instance_variable_get(variable_name)
-      elsif cached_tag_list_on(context) && self.class.caching_tag_list_on?(context)
+      elsif cached_tag_list_on(context) && ensure_included_cache_methods! && self.class.caching_tag_list_on?(context)
         instance_variable_set(variable_name, ActsAsTaggableOn.default_parser.new(cached_tag_list_on(context)).parse)
       else
         instance_variable_set(variable_name, ActsAsTaggableOn::TagList.new(tags_on(context).map(&:name)))
@@ -417,6 +417,10 @@ module ActsAsTaggableOn::Taggable
     end
 
     private
+
+    def ensure_included_cache_methods!
+      self.class.columns
+    end
 
     # Filters the tag lists from the attribute names.
     def attributes_for_update(attribute_names)

--- a/spec/acts_as_taggable_on/caching_spec.rb
+++ b/spec/acts_as_taggable_on/caching_spec.rb
@@ -99,6 +99,29 @@ describe 'Acts As Taggable On' do
     end
   end
 
+  describe 'Cache methods initialization on new models' do
+    before(:all) do
+      ActiveRecord::Schema.define do
+        create_table :cache_methods_injected_models do |t|
+          t.string :cached_tag_list
+        end
+      end
+      ActiveRecord::Base.connection.execute(
+        'INSERT INTO cache_methods_injected_models VALUES (NULL, \'ciao\')'
+      )
+      class CacheMethodsInjectedModel < ActiveRecord::Base
+        acts_as_taggable
+      end
+    end
+    after(:all) { Object.send(:remove_const, :CacheMethodsInjectedModel) }
+
+    it 'cached_tag_list_on? get injected correctly' do
+      expect do
+        CacheMethodsInjectedModel.first.tag_list
+      end.not_to raise_error
+    end
+  end
+
   describe 'CachingWithArray' do
     pending '#TODO'
   end

--- a/spec/acts_as_taggable_on/caching_spec.rb
+++ b/spec/acts_as_taggable_on/caching_spec.rb
@@ -101,13 +101,8 @@ describe 'Acts As Taggable On' do
 
   describe 'Cache methods initialization on new models' do
     before(:all) do
-      ActiveRecord::Schema.define do
-        create_table :cache_methods_injected_models do |t|
-          t.string :cached_tag_list
-        end
-      end
       ActiveRecord::Base.connection.execute(
-        'INSERT INTO cache_methods_injected_models VALUES (NULL, \'ciao\')'
+        'INSERT INTO cache_methods_injected_models (cached_tag_list) VALUES (\'ciao\')'
       )
       class CacheMethodsInjectedModel < ActiveRecord::Base
         acts_as_taggable

--- a/spec/internal/db/schema.rb
+++ b/spec/internal/db/schema.rb
@@ -78,6 +78,9 @@ ActiveRecord::Schema.define version: 0 do
     t.column :type, :string
   end
 
+  create_table :cache_methods_injected_models, force: true do |t|
+    t.column :cached_tag_list, :string
+  end
 
   # Special cases for postgresql
   if using_postgresql?


### PR DESCRIPTION
Fix #432
## Description:
On Rails 5 (I can't test on other environments right now), if you try to access to a cached tag list before the model as initialized for the first time, it fails with:

```
NoMethodError: undefined method `caching_tag_list_on?' for #<Class:0x007ff6aabcbb98>
```

## How to replicate:
You need a table with an existing record with a `cached_tag_list` column, populated with a non-null value.
Running `ModelName.first.tag_list` -> it throws `NoMethodError`.

Instead, calling `ModelName.columns` before this call, it generates no error.

This is because the `ModelName.columns` injects the `ActsAsTaggableOn::Taggable::Cache::InstanceMethods` in runtime.

Check out here:
https://github.com/mbleigh/acts-as-taggable-on/blob/8e64c3d4a81cfbb8af621228eae36a65c1f94501/lib/acts_as_taggable_on/taggable/cache.rb#L38

If you run it manually or initialize a new model (i.e. `ModelName.new`), it gets injected normally.

---

I added a spec to demonstrate the bug and a possible fix.

Let me know if it can be useful ;)
