### PR TITLE
Due to database collisions, retry when finding or creating a tag

### DIFF
--- a/lib/acts_as_taggable_on/tag.rb
+++ b/lib/acts_as_taggable_on/tag.rb
@@ -69,17 +69,20 @@ module ActsAsTaggableOn
 
       return [] if list.empty?
 
-      existing_tags = named_any(list)
-
       list.map do |tag_name|
-        comparable_tag_name = comparable_name(tag_name)
-        existing_tag = existing_tags.find { |tag| comparable_name(tag.name) == comparable_tag_name }
         begin
+          tries ||= 3
+
+          existing_tags = named_any(list)
+          comparable_tag_name = comparable_name(tag_name)
+          existing_tag = existing_tags.find { |tag| comparable_name(tag.name) == comparable_tag_name }
           existing_tag || create(name: tag_name)
         rescue ActiveRecord::RecordNotUnique
-          # Postgres aborts the current transaction with
-          # PG::InFailedSqlTransaction: ERROR:  current transaction is aborted, commands ignored until end of transaction block
-          # so we have to rollback this transaction
+          if (tries -= 1).positive?
+            ActiveRecord::Base.connection.execute 'ROLLBACK'
+            retry
+          end
+
           raise DuplicateTagError.new("'#{tag_name}' has already been taken")
         end
       end


### PR DESCRIPTION
This PR closes #693 

Since the [link](https://github.com/mbleigh/acts-as-taggable-on/issues/693#issuecomment-251493235) posted by @adam-e-trepanier is returning 404, I just implemented a retrial strategy described by Mark Quezada in this [blog post](http://blog.mirthlab.com/2012/05/25/cleanly-retrying-blocks-of-code-after-an-exception-in-ruby/).

Any suggestions are welcome! :)