### PR TITLE
Fixed Rails 5.1 deprecation message: Passing a class to the `class_name`...

### DIFF
--- a/lib/acts_as_taggable_on/taggable/core.rb
+++ b/lib/acts_as_taggable_on/taggable/core.rb
@@ -25,11 +25,11 @@ module ActsAsTaggableOn::Taggable
             # the associations tag_taggings & tags are always returned in created order
             has_many context_taggings, -> { includes(:tag).order(taggings_order).where(context: tags_type) },
                      as: :taggable,
-                     class_name: ActsAsTaggableOn::Tagging,
+                     class_name: 'ActsAsTaggableOn::Tagging',
                      dependent: :destroy
 
             has_many context_tags, -> { order(taggings_order) },
-                     class_name: ActsAsTaggableOn::Tag,
+                     class_name: 'ActsAsTaggableOn::Tag',
                      through: context_taggings,
                      source: :tag
           end

--- a/lib/acts_as_taggable_on/tagger.rb
+++ b/lib/acts_as_taggable_on/tagger.rb
@@ -20,12 +20,12 @@ module ActsAsTaggableOn
           has_many :owned_taggings, owned_taggings_scope,
                    opts.merge(
                      as: :tagger,
-                     class_name: ::ActsAsTaggableOn::Tagging,
+                     class_name: '::ActsAsTaggableOn::Tagging',
                      dependent: :destroy
                    )
 
           has_many :owned_tags, -> { distinct },
-                   class_name: ::ActsAsTaggableOn::Tag,
+                   class_name: '::ActsAsTaggableOn::Tag',
                    source: :tag,
                    through: :owned_taggings
         end


### PR DESCRIPTION
has_many needs a String value for class_name argument