### PR TITLE
Ability to use tags independently from different models

### DIFF
--- a/README.md
+++ b/README.md
@@ -424,6 +424,49 @@ CSS:
 .css4 { font-size: 1.6em; }
 ```
 
+### Exclusive tags depending on models
+
+Let's say you need a complete independent tag lists for 2 of your domain models,
+say `Order` and `Product`, so that they couldn't clash. Use `exclusive` parameter for that
+
+```ruby
+class Order < ActiveRecord::Base
+  acts_as_taggable exclusive: true
+end
+
+class Product < ActiveRecord::Base
+  acts_as_taggable exclusive: true
+end
+```
+
+And operate on orders and tags complete like usual, except tags will not clash:
+
+```ruby
+order = Order.create!
+order.tag_list = 'cool, nice, wow'
+order.save!
+
+product = Product.create!
+product.tag_list = 'super, nice'
+product.save!
+
+ActsAsTaggableOn::Tag.where(name: 'nice').count
+# => 2
+
+ActsAsTaggableOn::Tag.where(name: 'nice').pluck(:type)
+# => ["ActsAsTaggableOn::Tag::OrderTag", "ActsAsTaggableOn::Tag::ProductTag"]
+```
+
+You can also use this in your autocomplete endpoints:
+
+```ruby
+ActsAsTaggableOn::Tag.exclusively_for(:product).pluck(:name)
+# => ['cool', 'nice', 'wow']
+
+ActsAsTaggableOn::Tag.exclusively_for(:order).pluck(:name)
+# => ['super, 'nice']
+```
+
 ## Configuration
 
 If you would like to remove unused tag objects after removing taggings, add:

--- a/db/migrate/2_add_missing_unique_indices.rb
+++ b/db/migrate/2_add_missing_unique_indices.rb
@@ -1,6 +1,6 @@
 class AddMissingUniqueIndices < ActiveRecord::Migration
   def self.up
-    add_index :tags, :name, unique: true
+    add_index :tags, :name, unique: true unless index_exists?(:tags, :name)
 
     remove_index :taggings, :tag_id if index_exists?(:taggings, :tag_id)
     remove_index :taggings, [:taggable_id, :taggable_type, :context]
@@ -10,7 +10,7 @@ class AddMissingUniqueIndices < ActiveRecord::Migration
   end
 
   def self.down
-    remove_index :tags, :name
+    remove_index :tags, :name if index_exists?(:tags, :name)
 
     remove_index :taggings, name: 'taggings_idx'
 

--- a/db/migrate/7_add_type_for_tags.rb
+++ b/db/migrate/7_add_type_for_tags.rb
@@ -1,0 +1,7 @@
+class AddTypeForTags < ActiveRecord::Migration
+  def change
+    unless column_exists? :tags, :type
+      add_column :tags, :type, :string, null: false, default: 'ActsAsTaggableOn::Tag'
+    end
+  end
+end

--- a/db/migrate/8_add_type_into_index_for_tags.rb
+++ b/db/migrate/8_add_type_into_index_for_tags.rb
@@ -1,0 +1,13 @@
+class AddTypeIntoIndexForTags < ActiveRecord::Migration
+  disable_ddl_transaction!
+
+  def up
+    remove_index :tags, :name if index_exists?(:tags, :name)
+    add_index :tags, [:name, :type], unique: true, algorithm: :concurrently unless index_exists?(:tags, [:name, :type])
+  end
+
+  def down
+    remove_index :tags, [:name, :type] if index_exists?(:tags, [:name, :type])
+    add_index :tags, :name, unique: true, algorithm: :concurrently unless index_exists?(:tags, :name)
+  end
+end

--- a/lib/acts-as-taggable-on.rb
+++ b/lib/acts-as-taggable-on.rb
@@ -16,6 +16,7 @@ module ActsAsTaggableOn
 
   autoload :Tag
   autoload :TagList
+  autoload :TagClass
   autoload :GenericParser
   autoload :DefaultParser
   autoload :Taggable

--- a/lib/acts_as_taggable_on/tag.rb
+++ b/lib/acts_as_taggable_on/tag.rb
@@ -9,7 +9,7 @@ module ActsAsTaggableOn
     ### VALIDATIONS:
 
     validates_presence_of :name
-    validates_uniqueness_of :name, if: :validates_name_uniqueness?
+    validates_uniqueness_of :name, scope: [:type], if: :validates_name_uniqueness?
     validates_length_of :name, maximum: 255
 
     # monkey patch this method if don't need name uniqueness validation
@@ -20,6 +20,15 @@ module ActsAsTaggableOn
     ### SCOPES:
     scope :most_used, ->(limit = 20) { order('taggings_count desc').limit(limit) }
     scope :least_used, ->(limit = 20) { order('taggings_count asc').limit(limit) }
+
+    def self.exclusively_for(class_name)
+      tag_class_name = "#{class_name.to_s.singularize.camelize}Tag"
+      if self.const_defined? tag_class_name
+        self.const_get(tag_class_name).all
+      else
+        where(type: [name, nil])
+      end
+    end
 
     def self.named(name)
       if ActsAsTaggableOn.strict_case_match

--- a/lib/acts_as_taggable_on/tag_class.rb
+++ b/lib/acts_as_taggable_on/tag_class.rb
@@ -1,0 +1,15 @@
+module ActsAsTaggableOn
+  class TagClass
+    def initialize(class_name, base_class)
+      @class_name, @base_class = "#{class_name}Tag", base_class
+    end
+
+    def class
+      if @base_class.const_defined? @class_name
+        @base_class.const_get @class_name
+      else
+        @base_class.const_set @class_name, Class.new(@base_class)
+      end
+    end
+  end
+end

--- a/lib/acts_as_taggable_on/taggable/core.rb
+++ b/lib/acts_as_taggable_on/taggable/core.rb
@@ -20,7 +20,6 @@ module ActsAsTaggableOn::Taggable
           context_tags = tags_type.to_sym
           context_options = tag_options[tags_type] ||= Hash.new { |h,k| h[k] = {} }
           taggings_order = (preserve_tag_order? ? "#{ActsAsTaggableOn::Tagging.table_name}.id" : [])
-          taggings_tag_reference = (preserve_tag_order? ? :joins : :includes)
 
           if context_options[:exclusive]
             context_options[:tags_class] ||= ActsAsTaggableOn::TagClass.new(name, ActsAsTaggableOn::Tag).class
@@ -37,7 +36,7 @@ module ActsAsTaggableOn::Taggable
           class_eval do
             # when preserving tag order, include order option so that for a 'tags' context
             # the associations tag_taggings & tags are always returned in created order
-            has_many context_taggings, -> { send(taggings_tag_reference, :tag).order(taggings_order).where(context: tags_type) },
+            has_many context_taggings, -> { includes(:tag).references(:tag).order(taggings_order).where(context: tags_type) },
                      as: :taggable,
                      class_name: context_options[:taggings_class].name,
                      dependent: :destroy

--- a/lib/acts_as_taggable_on/taggable/core.rb
+++ b/lib/acts_as_taggable_on/taggable/core.rb
@@ -20,6 +20,7 @@ module ActsAsTaggableOn::Taggable
           context_tags = tags_type.to_sym
           context_options = tag_options[tags_type] ||= Hash.new { |h,k| h[k] = {} }
           taggings_order = (preserve_tag_order? ? "#{ActsAsTaggableOn::Tagging.table_name}.id" : [])
+          taggings_tag_reference = (preserve_tag_order? ? :joins : :includes)
 
           if context_options[:exclusive]
             context_options[:tags_class] ||= ActsAsTaggableOn::TagClass.new(name, ActsAsTaggableOn::Tag).class
@@ -36,7 +37,7 @@ module ActsAsTaggableOn::Taggable
           class_eval do
             # when preserving tag order, include order option so that for a 'tags' context
             # the associations tag_taggings & tags are always returned in created order
-            has_many context_taggings, -> { includes(:tag).order(taggings_order).where(context: tags_type) },
+            has_many context_taggings, -> { send(taggings_tag_reference, :tag).order(taggings_order).where(context: tags_type) },
                      as: :taggable,
                      class_name: context_options[:taggings_class].name,
                      dependent: :destroy

--- a/lib/acts_as_taggable_on/taggable/core.rb
+++ b/lib/acts_as_taggable_on/taggable/core.rb
@@ -380,13 +380,9 @@ module ActsAsTaggableOn::Taggable
     # Find existing tags or create non-existing tags
     def load_tags(tag_list, _context='tags')
       context_options = tag_options[_context.to_s]
-      if context_options[:exclusive]
-        base_relation_name = context_options[:base_tags_relation] || :base_tags
-        send(base_relation_name).find_or_create_all_with_like_by_name(tag_list)
-      else
-        tags_class = context_options[:tags_class] || ActsAsTaggableOn::Tag
-        tags_class.find_or_create_all_with_like_by_name(tag_list)
-      end
+      tags_class = context_options[:tags_class] if context_options[:exclusive]
+      tags_class ||= ActsAsTaggableOn::Tag
+      tags_class.find_or_create_all_with_like_by_name(tag_list)
     end
 
     def save_tags

--- a/lib/acts_as_taggable_on/taggable/core.rb
+++ b/lib/acts_as_taggable_on/taggable/core.rb
@@ -18,18 +18,31 @@ module ActsAsTaggableOn::Taggable
           tag_type = tags_type.to_s.singularize
           context_taggings = "#{tag_type}_taggings".to_sym
           context_tags = tags_type.to_sym
+          context_options = tag_options[tags_type] ||= Hash.new { |h,k| h[k] = {} }
           taggings_order = (preserve_tag_order? ? "#{ActsAsTaggableOn::Tagging.table_name}.id" : [])
+
+          if context_options[:exclusive]
+            context_options[:tags_class] ||= ActsAsTaggableOn::TagClass.new(name, ActsAsTaggableOn::Tag).class
+            context_options[:taggings_class] ||= ActsAsTaggableOn::TagClass.new(name, ActsAsTaggableOn::Tagging).class
+            context_options[:base_tags_relation] = context_tags
+            context_options[:base_taggings_relation] = context_taggings
+          else
+            context_options[:tags_class] = ActsAsTaggableOn::Tag
+            context_options[:taggings_class] = ActsAsTaggableOn::Tagging
+            context_options[:base_tags_relation] = :base_tags
+            context_options[:base_taggings_relation] = :taggings
+          end
 
           class_eval do
             # when preserving tag order, include order option so that for a 'tags' context
             # the associations tag_taggings & tags are always returned in created order
             has_many context_taggings, -> { includes(:tag).order(taggings_order).where(context: tags_type) },
                      as: :taggable,
-                     class_name: 'ActsAsTaggableOn::Tagging',
+                     class_name: context_options[:taggings_class].name,
                      dependent: :destroy
 
             has_many context_tags, -> { order(taggings_order) },
-                     class_name: 'ActsAsTaggableOn::Tag',
+                     class_name: context_options[:tags_class].name,
                      through: context_taggings,
                      source: :tag
           end
@@ -99,6 +112,7 @@ module ActsAsTaggableOn::Taggable
         alias_base_name = undecorated_table_name.gsub('.', '_')
         # FIXME use ActiveRecord's connection quote_column_name
         quote = ActsAsTaggableOn::Utils.using_postgresql? ? '"' : ''
+        tag_class = tag_options[(context || 'tags').to_s][:tag_class] || ActsAsTaggableOn::Tag
 
         if options.delete(:exclude)
           if options.delete(:wild)
@@ -123,9 +137,9 @@ module ActsAsTaggableOn::Taggable
         elsif options.delete(:any)
           # get tags, drop out if nothing returned (we need at least one)
           tags = if options.delete(:wild)
-                   ActsAsTaggableOn::Tag.named_like_any(tag_list)
+                   tag_class.named_like_any(tag_list)
                  else
-                   ActsAsTaggableOn::Tag.named_any(tag_list)
+                   tag_class.named_any(tag_list)
                  end
 
           return empty_result if tags.length == 0
@@ -166,7 +180,7 @@ module ActsAsTaggableOn::Taggable
             order_by << "(SELECT count(*) FROM #{tagging_cond}) desc"
           end
         else
-          tags = ActsAsTaggableOn::Tag.named_any(tag_list)
+          tags = tag_class.named_any(tag_list)
 
           return empty_result unless tags.length == tag_list.length
 
@@ -300,7 +314,8 @@ module ActsAsTaggableOn::Taggable
       tagging_table_name = ActsAsTaggableOn::Tagging.table_name
 
       opts = ["#{tagging_table_name}.context = ?", context.to_s]
-      scope = base_tags.where(opts)
+      base_relation_name = tag_options[context.to_s][:base_tags_relation] || :base_tags
+      scope = send(base_relation_name).where(opts)
 
       if ActsAsTaggableOn::Utils.using_postgresql?
         group_columns = grouped_column_names_for(ActsAsTaggableOn::Tag)
@@ -313,7 +328,7 @@ module ActsAsTaggableOn::Taggable
     ##
     # Returns all tags that are not owned of a given context
     def tags_on(context)
-      scope = base_tags.where(["#{ActsAsTaggableOn::Tagging.table_name}.context = ? AND #{ActsAsTaggableOn::Tagging.table_name}.tagger_id IS NULL", context.to_s])
+      scope = send(tag_options[context.to_s][:base_tags_relation] || :base_tags).where(["#{ActsAsTaggableOn::Tagging.table_name}.context = ? AND #{ActsAsTaggableOn::Tagging.table_name}.tagger_id IS NULL", context.to_s]) rescue byebug
       # when preserving tag order, return tags in created order
       # if we added the order to the association this would always apply
       scope = scope.order("#{ActsAsTaggableOn::Tagging.table_name}.id") if self.class.preserve_tag_order?
@@ -362,8 +377,15 @@ module ActsAsTaggableOn::Taggable
 
     ##
     # Find existing tags or create non-existing tags
-    def load_tags(tag_list)
-      ActsAsTaggableOn::Tag.find_or_create_all_with_like_by_name(tag_list)
+    def load_tags(tag_list, _context='tags')
+      context_options = tag_options[_context.to_s]
+      if context_options[:exclusive]
+        base_relation_name = context_options[:base_tags_relation] || :base_tags
+        send(base_relation_name).find_or_create_all_with_like_by_name(tag_list)
+      else
+        tags_class = context_options[:tags_class] || ActsAsTaggableOn::Tag
+        tags_class.find_or_create_all_with_like_by_name(tag_list)
+      end
     end
 
     def save_tags
@@ -402,14 +424,16 @@ module ActsAsTaggableOn::Taggable
           new_tags = tags - current_tags
         end
 
+        taggings_relation_name = self.class.tag_options[context.to_s][:base_taggings_relation] || :taggings
+
         # Destroy old taggings:
         if old_tags.present?
-          taggings.not_owned.by_context(context).where(tag_id: old_tags).destroy_all
+          send(taggings_relation_name).not_owned.by_context(context).where(tag_id: old_tags).destroy_all
         end
 
         # Create new taggings:
         new_tags.each do |tag|
-          taggings.create!(tag_id: tag.id, context: context.to_s, taggable: self)
+          send(taggings_relation_name).create!(tag_id: tag.id, context: context.to_s, taggable: self)
         end
       end
 
@@ -450,7 +474,7 @@ module ActsAsTaggableOn::Taggable
     # @param [Array<String>] tag_list Tags to find or create
     # @param [Symbol] context The tag context for the tag_list
     def find_or_create_tags_from_list_with_context(tag_list, _context)
-      load_tags(tag_list)
+      load_tags(tag_list, _context)
     end
   end
 end

--- a/spec/acts_as_taggable_on/acts_as_taggable_on_spec.rb
+++ b/spec/acts_as_taggable_on/acts_as_taggable_on_spec.rb
@@ -319,6 +319,16 @@ describe 'Acts As Taggable On' do
         expect(ActsAsTaggableOn::Tag.where(name: 'green').count).to eq 2
         expect(ActsAsTaggableOn::Tag.where(name: 'green').pluck(:type)).to match_array ["ActsAsTaggableOn::Tag::OtherTaggableModelTag", "ActsAsTaggableOn::Tag::TaggableModelTag"]
       end
+
+      it 'loads tags from specific subclass' do
+        expect {
+          taggable3 = OtherTaggableModel.create!(name: 'Other Taggable 3')
+          taggable3.color_list = 'blue, orange, green'
+          taggable3.save!
+        }.not_to change { ActsAsTaggableOn::Tag.count }
+
+        expect(ActsAsTaggableOn::Tag::OtherTaggableModelTag.where(name: 'green').pluck(:taggings_count)).to eq [2]
+      end
     end
 
     describe 'with order' do

--- a/spec/acts_as_taggable_on/acts_as_taggable_on_spec.rb
+++ b/spec/acts_as_taggable_on/acts_as_taggable_on_spec.rb
@@ -321,20 +321,6 @@ describe 'Acts As Taggable On' do
       end
     end
 
-    describe 'without order' do
-      before do
-        TaggableModel.acts_as_taggable_on(:colors, exclusive: true)
-        OtherTaggableModel.acts_as_taggable_on(:colors, exclusive: true)
-      end
-
-      include_examples 'exclusive filtered tags'
-
-      it 'allows to choose only specific tags if marked so' do
-        expect(TaggableModel.includes(:colors).first.colors.map(&:name)).to match_array %w[red yellow green]
-        expect(OtherTaggableModel.includes(:colors).first.colors.map(&:name)).to match_array %w[blue orange green]
-      end
-    end
-
     describe 'with order' do
       before do
         TaggableModel.acts_as_ordered_taggable_on(:colors, exclusive: true)
@@ -346,6 +332,20 @@ describe 'Acts As Taggable On' do
       it 'allows to choose only specific tags if marked so' do
         expect(TaggableModel.includes(:colors).first.colors.map(&:name)).to eq %w[red yellow green]
         expect(OtherTaggableModel.includes(:colors).first.colors.map(&:name)).to eq %w[blue orange green]
+      end
+    end
+
+    describe 'without order' do
+      before do
+        TaggableModel.acts_as_taggable_on(:colors, exclusive: true)
+        OtherTaggableModel.acts_as_taggable_on(:colors, exclusive: true)
+      end
+
+      include_examples 'exclusive filtered tags'
+
+      it 'allows to choose only specific tags if marked so' do
+        expect(TaggableModel.includes(:colors).first.colors.map(&:name)).to match_array %w[red yellow green]
+        expect(OtherTaggableModel.includes(:colors).first.colors.map(&:name)).to match_array %w[blue orange green]
       end
     end
   end

--- a/spec/acts_as_taggable_on/tag_class_spec.rb
+++ b/spec/acts_as_taggable_on/tag_class_spec.rb
@@ -1,0 +1,23 @@
+# -*- encoding : utf-8 -*-
+
+require 'spec_helper'
+
+describe ActsAsTaggableOn::TagClass do
+  let(:base_class) { ActsAsTaggableOn::Tag }
+
+  class ActsAsTaggableOn::Tag::TestTag
+  end
+
+  describe '#class' do
+    it 'should create subclass no not exists' do
+      subject = described_class.new("Product", base_class).class
+      expect(subject.name).to eq 'ActsAsTaggableOn::Tag::ProductTag'
+      expect(subject.superclass).to eq base_class
+    end
+
+    it 'should use existing subclass' do
+      subject = described_class.new("Test", base_class).class
+      expect(subject).to eq ActsAsTaggableOn::Tag::TestTag
+    end
+  end
+end

--- a/spec/acts_as_taggable_on/taggable_spec.rb
+++ b/spec/acts_as_taggable_on/taggable_spec.rb
@@ -530,6 +530,24 @@ describe 'Taggable' do
     end
   end
 
+  it 'should find tags inside given scope' do
+    frank = TaggableModel.create(name: 'Frank', tag_list: 'fitter, lazy')
+    steve = TaggableModel.create(name: 'Steve', tag_list: 'fitter, happier')
+    bob = TaggableModel.create(name: 'Bob', tag_list: 'more productive')
+    scope = ActsAsTaggableOn::Tag.where('taggings_count > ?', 1)
+
+    expect(TaggableModel.tagged_with('fitter, happier, more productive, lazy', default_scope: scope)).to include(frank, steve)
+  end
+
+  it 'should respect none-scope' do
+    frank = TaggableModel.create(name: 'Frank', tag_list: 'fitter, lazy')
+    steve = TaggableModel.create(name: 'Steve', tag_list: 'fitter, happier')
+    bob = TaggableModel.create(name: 'Bob', tag_list: 'more productive')
+    scope = ActsAsTaggableOn::Tag.none
+
+    expect(TaggableModel.tagged_with('fitter, happier, more productive, lazy', default_scope: scope)).to be_blank
+  end
+
   it 'should options key not be deleted' do
     options = {:exclude => true}
     TaggableModel.tagged_with("foo", options)

--- a/spec/internal/db/schema.rb
+++ b/spec/internal/db/schema.rb
@@ -4,7 +4,7 @@ ActiveRecord::Schema.define version: 0 do
     t.integer :taggings_count, default: 0
     t.string :type
   end
-  add_index 'tags', ['name'], name: 'index_tags_on_name', unique: true
+  add_index 'tags', ['name', 'type'], name: 'index_tags_on_name_and_type', unique: true
 
   create_table :taggings, force: true do |t|
     t.integer :tag_id


### PR DESCRIPTION
This PR is based on 2 issues:

1) when used on different models, tags get unified by name and `taggings_count` shows sum across all models 
2) for a simple thing like "get all tags applicable to 1 model, not to others" we have to aggregate through taggings like group by type, use ids to select tag records and counts instead of taggings_count.

After PR we can use an option to split tags exclusively for a model
```ruby
class Order < ActiveRecord::Base
  acts_as_taggable exclusive: true # this will isolate order tags completely
end

# and use additional dsl to get needed tags only
ActsAsTaggableOn::Tag.exclusively_for(:order)
```

For further details please, see updated readme and a new [spec](https://github.com/razum2um/acts-as-taggable-on/blob/master/spec/acts_as_taggable_on/acts_as_taggable_on_spec.rb#L304L324) :)

P.S. I saw [find_or_create_tags_from_list_with_context](https://github.com/mbleigh/acts-as-taggable-on/blob/master/lib/acts_as_taggable_on/taggable/core.rb#L433L454) in the code, but I think this hook looks kinda ugly, exclusively option makes this useless, as you can pass a `tags_class` directly and it will work out of the box.

Do you like the idea of PR?
I also thought about making `type` column optional and commentabe/uncommentable in migration for users which don't wont to migrate possible huge tables, but WDYT about default behaviour?
