### PR TITLE
Fix a bug on ActAsTaggableOn::Tag.find_or_create_with_like_by_name

### DIFF
--- a/lib/acts_as_taggable_on/tag.rb
+++ b/lib/acts_as_taggable_on/tag.rb
@@ -60,7 +60,7 @@ module ActsAsTaggableOn
       if ActsAsTaggableOn.strict_case_match
         self.find_or_create_all_with_like_by_name([name]).first
       else
-        named_like(name).first || create(name: name)
+        named_like(name).first || create!(name: name)
       end
     end
 
@@ -75,7 +75,7 @@ module ActsAsTaggableOn
         comparable_tag_name = comparable_name(tag_name)
         existing_tag = existing_tags.find { |tag| comparable_name(tag.name) == comparable_tag_name }
         begin
-          existing_tag || create(name: tag_name)
+          existing_tag || create!(name: tag_name)
         rescue ActiveRecord::RecordNotUnique
           # Postgres aborts the current transaction with
           # PG::InFailedSqlTransaction: ERROR:  current transaction is aborted, commands ignored until end of transaction block

--- a/spec/acts_as_taggable_on/tag_spec.rb
+++ b/spec/acts_as_taggable_on/tag_spec.rb
@@ -89,6 +89,14 @@ describe ActsAsTaggableOn::Tag do
         ActsAsTaggableOn::Tag.find_or_create_with_like_by_name('epic')
       }).to change(ActsAsTaggableOn::Tag, :count).by(1)
     end
+
+    context 'when invalid name' do
+      it 'should raise error' do
+        expect {
+          ActsAsTaggableOn::Tag.find_or_create_all_with_like_by_name('fgkgnkkgjymkypbuozmwwghblmzpqfsgjasflblywhgkwndnkzeifalfcpeaeqychjuuowlacmuidnnrkprgpcpybarbkrmziqihcrxirlokhnzfvmtzixgvhlxzncyywficpraxfnjptxxhkqmvicbcdcynkjvziefqzyndxkjmsjlvyvbwraklbalykyxoliqdlreeykuphdtmzfdwpphmrqvwvqffojkqhlzvinqajsxbszyvrqqyzusxranr')
+        }.to raise_error(ActiveRecord::RecordInvalid)
+      end
+    end
   end
 
   describe 'find or create by unicode name', unless: using_sqlite? do
@@ -143,6 +151,14 @@ describe ActsAsTaggableOn::Tag do
       expect {
         ActsAsTaggableOn::Tag.find_or_create_all_with_like_by_name('epic')
       }.to change(ActsAsTaggableOn::Tag, :count).by(1)
+    end
+
+    context 'when invalid name' do
+      it 'should raise error' do
+        expect {
+          ActsAsTaggableOn::Tag.find_or_create_all_with_like_by_name('fgkgnkkgjymkypbuozmwwghblmzpqfsgjasflblywhgkwndnkzeifalfcpeaeqychjuuowlacmuidnnrkprgpcpybarbkrmziqihcrxirlokhnzfvmtzixgvhlxzncyywficpraxfnjptxxhkqmvicbcdcynkjvziefqzyndxkjmsjlvyvbwraklbalykyxoliqdlreeykuphdtmzfdwpphmrqvwvqffojkqhlzvinqajsxbszyvrqqyzusxranr')
+        }.to raise_error(ActiveRecord::RecordInvalid)
+      end
     end
 
     context 'case sensitive' do


### PR DESCRIPTION
Hi :)
I found a weird issue.
Passing too long name(over 255 characters) to `ActAsTaggableOn::Tag.find_or_create_with_like_by_name`, it returns not persisted instance.
Because inside `.create` method returns not persisted instance when instance is invalid.

This issue occurs some problems.
For example,  `ActsAsTaggableOn::Taggable#save_tags` fails with 'Tag can't be blank'. It is hard to find [reason](https://github.com/mbleigh/acts-as-taggable-on/blob/v4.0.0/lib/acts_as_taggable_on/taggable/core.rb#L420).

This patch fixes that issues.
Please check this out and release to rubygems as soon as possible.
Thanks 👻 