### PR TITLE
Fix a problem on ActsAsTaggableOn::Taggings#save_tags

### DIFF
--- a/lib/acts_as_taggable_on/taggable/core.rb
+++ b/lib/acts_as_taggable_on/taggable/core.rb
@@ -409,6 +409,7 @@ module ActsAsTaggableOn::Taggable
 
         # Create new taggings:
         new_tags.each do |tag|
+          tag.validate!
           taggings.create!(tag_id: tag.id, context: context.to_s, taggable: self)
         end
       end

--- a/spec/acts_as_taggable_on/taggable_spec.rb
+++ b/spec/acts_as_taggable_on/taggable_spec.rb
@@ -161,6 +161,25 @@ describe 'Taggable' do
     expect(@taggable.skill_list.sort).to eq(%w(ruby rails css).sort)
   end
 
+  context 'when invalid tag name is passed' do
+    context 'and call save' do
+      it 'should not be able to create tags' do
+        @taggable.tag_list << ('a' * 256)
+
+        expect{ @taggable.save }.not_to change(ActsAsTaggableOn::Tag, :count)
+        expect{ @taggable.save }.not_to raise_error
+      end
+    end
+
+    context 'and call save!' do
+      it 'should raise validation error' do
+        @taggable.tag_list << ('a' * 256)
+
+        expect{ @taggable.save! }.to raise_error(ActiveRecord::RecordInvalid, /Validation failed: Name is too long/)
+      end
+    end
+  end
+
   it 'should be able to create tags through the tag list directly' do
     @taggable.tag_list_on(:test).add('hello')
     expect(@taggable.tag_list_cache_on(:test)).to_not be_empty


### PR DESCRIPTION
Related #821 
`ActsAsTaggableOn::Taggable#save_tags` fails with 'Tag can't be blank' when too long name(over 255 characters) is passed.
This patch fix it.