### PR TITLE
`cached_tag_list` column is ignored

### DIFF
--- a/lib/acts_as_taggable_on/taggable/core.rb
+++ b/lib/acts_as_taggable_on/taggable/core.rb
@@ -107,8 +107,12 @@ module ActsAsTaggableOn::Taggable
       self.class.grouped_column_names_for(object)
     end
 
+    def unpersisted_custom_contexts
+      @unsaved_custom_contexts ||= []
+    end
+
     def custom_contexts
-      @custom_contexts ||= taggings.map(&:context).uniq
+      @custom_contexts ||= (taggings.map(&:context) + unpersisted_custom_contexts).uniq
     end
 
     def is_taggable?
@@ -117,6 +121,14 @@ module ActsAsTaggableOn::Taggable
 
     def add_custom_context(value)
       custom_contexts << value.to_s unless custom_contexts.include?(value.to_s) or self.class.tag_types.map(&:to_s).include?(value.to_s)
+    end
+
+    def add_custom_context_lazy(value)
+      if @custom_contexts.nil?
+        unpersisted_custom_contexts << value.to_s
+      else
+        add_custom_context(value)
+      end
     end
 
     def cached_tag_list_on(context)
@@ -140,7 +152,7 @@ module ActsAsTaggableOn::Taggable
     end
 
     def tag_list_on(context)
-      add_custom_context(context)
+      add_custom_context_lazy(context)
       tag_list_cache_on(context)
     end
 

--- a/lib/acts_as_taggable_on/taggable/core.rb
+++ b/lib/acts_as_taggable_on/taggable/core.rb
@@ -108,7 +108,7 @@ module ActsAsTaggableOn::Taggable
     end
 
     def unpersisted_custom_contexts
-      @unsaved_custom_contexts ||= []
+      @unpersisted_custom_contexts ||= []
     end
 
     def custom_contexts

--- a/spec/acts_as_taggable_on/caching_spec.rb
+++ b/spec/acts_as_taggable_on/caching_spec.rb
@@ -16,6 +16,17 @@ describe 'Acts As Taggable On' do
       expect(@taggable).to respond_to(:save_tags)
     end
 
+    it 'should perform no queries when reading from the cached column' do
+      stored_model = CachedModel.create!(tag_list: 'lol, lol2')
+      reloaded_model = CachedModel.find(stored_model.id)
+      count = count_queries! { reloaded_model.tag_list_cache_on(:tags) }
+
+      expect(count).to be_zero
+
+      count = count_queries! { reloaded_model.tag_list }
+      expect(count).to be_zero
+    end
+
     it 'should add cached tag lists to the instance if cached column is not present' do
       expect(TaggableModel.new(name: 'Art Kram')).to_not respond_to(:save_cached_tag_list)
     end

--- a/spec/support/0-helpers.rb
+++ b/spec/support/0-helpers.rb
@@ -30,3 +30,15 @@ end
 def using_case_insensitive_collation?
   using_mysql? && ActsAsTaggableOn::Utils.connection.collation =~ /_ci\Z/
 end
+
+def count_queries!
+  query_count = 0
+  instance = ActiveSupport::Notifications.subscribe 'sql.active_record' do
+    query_count += 1
+  end
+  yield
+  query_count
+ensure
+  ActiveSupport::Notifications.unsubscribe(instance) if instance
+  query_count
+end


### PR DESCRIPTION
Just a spec demonstrating that the `cached_tag_list` column is ignored when calling `tag_list`.

The strange thing is that, instead, `tag_list_cache_on(:tags)` works as expected.

Still investigating.


The failing line is this one:
https://github.com/mbleigh/acts-as-taggable-on/pull/830/files#diff-0bfae9e63c455d336360aad3c5266d9aR27