### PR TITLE
Avoid unnecessary queries when finding or creating tags

### DIFF
--- a/lib/acts_as_taggable_on/tag.rb
+++ b/lib/acts_as_taggable_on/tag.rb
@@ -69,17 +69,17 @@ module ActsAsTaggableOn
 
       return [] if list.empty?
 
+      existing_tags = named_any(list)
       list.map do |tag_name|
         begin
           tries ||= 3
-
-          existing_tags = named_any(list)
           comparable_tag_name = comparable_name(tag_name)
           existing_tag = existing_tags.find { |tag| comparable_name(tag.name) == comparable_tag_name }
           existing_tag || create(name: tag_name)
         rescue ActiveRecord::RecordNotUnique
           if (tries -= 1).positive?
             ActiveRecord::Base.connection.execute 'ROLLBACK'
+            existing_tags = named_any(list)
             retry
           end
 


### PR DESCRIPTION
This is an optimisation to avoid database queries when finding or creating a list tags in `ActsAsTaggableOn::Tag find_or_create_all_with_like_by_name`:

 The list of tags to be retrieved is only updated once and refreshed again in case there is a tag name collision.

This solves [#838](https://github.com/mbleigh/acts-as-taggable-on/issues/838) issue

   