### PR TITLE
Lower required Ruby version to 2.2.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ cache: bundler
 rvm:
   - 2.4.1
   - 2.3.3
-  - 2.2.7
+  - 2.2.2
 
 env:
   - DB=sqlite3

--- a/acts-as-taggable-on.gemspec
+++ b/acts-as-taggable-on.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
   gem.files         = `git ls-files`.split($/)
   gem.test_files    = gem.files.grep(%r{^spec/})
   gem.require_paths = ['lib']
-  gem.required_ruby_version     = '>= 2.2.7'
+  gem.required_ruby_version     = '>= 2.2.2'
 
   if File.exist?('UPGRADING.md')
     gem.post_install_message = File.read('UPGRADING.md')


### PR DESCRIPTION
Rails 5 itself has this as lowest Ruby version allowed.

If we keep the 2.2.7 as before we break a lot of Rails apps
and Rails engines that allow Ruby 2.2.2.

I didn't find a reason to not support 2.2.2.