### PR TITLE
Added find_all_related_for which finds tags no matter the tagger

### DIFF
--- a/lib/acts_as_taggable_on/taggable/related.rb
+++ b/lib/acts_as_taggable_on/taggable/related.rb
@@ -17,6 +17,17 @@ module ActsAsTaggableOn::Taggable
             def find_related_#{tag_type}_for(klass, options = {})
               related_tags_for('#{tag_type}', klass, options)
             end
+
+            #no matter the owner
+            def find_all_related_#{tag_type}(options = {})
+              related_all_tags_for('#{tag_type}', self.class, options)
+            end
+            alias_method :find_all_related_on_#{tag_type}, :find_all_related_#{tag_type}
+
+            def find_all_related_#{tag_type}_for(klass, options = {})
+              related_all_tags_for('#{tag_type}', klass, options)
+            end
+
           RUBY
         end
       end
@@ -43,6 +54,12 @@ module ActsAsTaggableOn::Taggable
     def related_tags_for(context, klass, options = {})
       tags_to_ignore = Array.wrap(options[:ignore]).map(&:to_s) || []
       tags_to_find = tags_on(context).map { |t| t.name }.reject { |t| tags_to_ignore.include? t }
+      related_where(klass, ["#{exclude_self(klass, id)} #{klass.table_name}.#{klass.primary_key} = #{ActsAsTaggableOn::Tagging.table_name}.taggable_id AND #{ActsAsTaggableOn::Tagging.table_name}.taggable_type = '#{klass.base_class}' AND #{ActsAsTaggableOn::Tagging.table_name}.tag_id = #{ActsAsTaggableOn::Tag.table_name}.#{ActsAsTaggableOn::Tag.primary_key} AND #{ActsAsTaggableOn::Tag.table_name}.name IN (?) AND #{ActsAsTaggableOn::Tagging.table_name}.context = ?", tags_to_find, context])
+    end
+
+    def related_all_tags_for(context, klass, options = {})
+      tags_to_ignore = Array.wrap(options[:ignore]).map(&:to_s) || []
+      tags_to_find = all_tags_on(context).map { |t| t.name }.reject { |t| tags_to_ignore.include? t }
       related_where(klass, ["#{exclude_self(klass, id)} #{klass.table_name}.#{klass.primary_key} = #{ActsAsTaggableOn::Tagging.table_name}.taggable_id AND #{ActsAsTaggableOn::Tagging.table_name}.taggable_type = '#{klass.base_class}' AND #{ActsAsTaggableOn::Tagging.table_name}.tag_id = #{ActsAsTaggableOn::Tag.table_name}.#{ActsAsTaggableOn::Tag.primary_key} AND #{ActsAsTaggableOn::Tag.table_name}.name IN (?) AND #{ActsAsTaggableOn::Tagging.table_name}.context = ?", tags_to_find, context])
     end
 


### PR DESCRIPTION
Added the ability to find related taggable objects no matter the tagger.
It was unavailable before.