### PR TITLE
Bugfix: 'context' does not work properly under a specific condition

### DIFF
--- a/lib/acts_as_taggable_on/taggable/tagged_with_query/all_tags_query.rb
+++ b/lib/acts_as_taggable_on/taggable/tagged_with_query/all_tags_query.rb
@@ -49,7 +49,7 @@ module ActsAsTaggableOn::Taggable::TaggedWithQuery
       end
 
       if options[:on].present?
-        on_condition = on_condition.and(tagging_alias[:context].lteq(options[:on]))
+        on_condition = on_condition.and(tagging_alias[:context].eq(options[:on]))
       end
 
       if (owner = options[:owned_by]).present?
@@ -75,7 +75,7 @@ module ActsAsTaggableOn::Taggable::TaggedWithQuery
       end
 
       if options[:on].present?
-        on_condition = on_condition.and(tagging_arel_table[:context].lteq(options[:on]))
+        on_condition = on_condition.and(tagging_arel_table[:context].eq(options[:on]))
       end
 
       on_condition

--- a/lib/acts_as_taggable_on/taggable/tagged_with_query/any_tags_query.rb
+++ b/lib/acts_as_taggable_on/taggable/tagged_with_query/any_tags_query.rb
@@ -38,7 +38,7 @@ module ActsAsTaggableOn::Taggable::TaggedWithQuery
       end
 
       if options[:on].present?
-        exists_contition = exists_contition.and(tagging_arel_table[:context].lteq(options[:on]))
+        exists_contition = exists_contition.and(tagging_arel_table[:context].eq(options[:on]))
       end
 
       if (owner = options[:owned_by]).present?

--- a/lib/acts_as_taggable_on/taggable/tagged_with_query/exclude_tags_query.rb
+++ b/lib/acts_as_taggable_on/taggable/tagged_with_query/exclude_tags_query.rb
@@ -63,7 +63,7 @@ module ActsAsTaggableOn::Taggable::TaggedWithQuery
       end
 
       if options[:on].present?
-        on_condition = on_condition.and(tagging_arel_table[:context].lteq(options[:on]))
+        on_condition = on_condition.and(tagging_arel_table[:context].eq(options[:on]))
       end
 
       on_condition

--- a/spec/acts_as_taggable_on/taggable_spec.rb
+++ b/spec/acts_as_taggable_on/taggable_spec.rb
@@ -263,7 +263,9 @@ describe 'Taggable' do
     expect(TaggableModel.tagged_with('ruby, css').first).to eq(@taggable)
     expect(TaggableModel.tagged_with('bob', on: :skills).first).to_not eq(@taggable)
     expect(TaggableModel.tagged_with('bob', on: :tags).first).to eq(@taggable)
+    expect(TaggableModel.tagged_with('julia', on: :skills).size).to eq(1)
     expect(TaggableModel.tagged_with('julia', on: :tags).size).to eq(1)
+    expect(TaggableModel.tagged_with('julia', on: nil).size).to eq(2)
   end
 
   it 'should not care about case' do

--- a/spec/acts_as_taggable_on/taggable_spec.rb
+++ b/spec/acts_as_taggable_on/taggable_spec.rb
@@ -255,14 +255,15 @@ describe 'Taggable' do
   end
 
   it 'should be able to find by tag with context' do
-    @taggable.skill_list = 'ruby, rails, css'
-    @taggable.tag_list = 'bob, charlie'
+    @taggable.skill_list = 'ruby, rails, css, julia'
+    @taggable.tag_list = 'bob, charlie, julia'
     @taggable.save
 
     expect(TaggableModel.tagged_with('ruby').first).to eq(@taggable)
     expect(TaggableModel.tagged_with('ruby, css').first).to eq(@taggable)
     expect(TaggableModel.tagged_with('bob', on: :skills).first).to_not eq(@taggable)
     expect(TaggableModel.tagged_with('bob', on: :tags).first).to eq(@taggable)
+    expect(TaggableModel.tagged_with('julia', on: :tags).size).to eq(1)
   end
 
   it 'should not care about case' do


### PR DESCRIPTION
If `taggable` has the following tags:
```
taggable = TaggableModel.new(name: 'Bob Jones')
taggable.skill_list = 'ruby, rails, css, julia'
taggable.tag_list = 'bob, charlie, julia'
taggable.save
```

`TaggableModel.tagged_with('julia', on: :tags).size` returns 2 instead of 1.

The bug has been introduced by https://github.com/mbleigh/acts-as-taggable-on/commit/64ed839a8a6021c719fbff9c6bdf74a4fcd65f18