### PR TITLE
Allow multiple contexts to be specified in for_context

### DIFF
--- a/lib/acts_as_taggable_on/tag.rb
+++ b/lib/acts_as_taggable_on/tag.rb
@@ -49,9 +49,16 @@ module ActsAsTaggableOn
       where(clause)
     end
 
-    def self.for_context(context)
+    def self.for_context(*contexts)
+      contexts = contexts.flatten
+      clause = if contexts.length > 1
+        "#{ActsAsTaggableOn.taggings_table}.context IN (?)"
+      else
+        "#{ActsAsTaggableOn.taggings_table}.context = ?"
+      end
+
       joins(:taggings).
-        where(["#{ActsAsTaggableOn.taggings_table}.context = ?", context]).
+        where([clause, contexts]).
         select("DISTINCT #{ActsAsTaggableOn.tags_table}.*")
     end
 

--- a/spec/acts_as_taggable_on/tag_spec.rb
+++ b/spec/acts_as_taggable_on/tag_spec.rb
@@ -68,6 +68,18 @@ describe ActsAsTaggableOn::Tag do
     it 'should not return tags that have been used in other contexts' do
       expect(ActsAsTaggableOn::Tag.for_context('needs').pluck(:name)).to_not include('ruby')
     end
+
+    context 'when multiple contexts are specified' do
+      before do
+        @user.language_list.add('go')
+        @user.save
+      end
+
+      it 'should return tags that have been used in all given contexts' do
+        expect(ActsAsTaggableOn::Tag.for_context('skills', 'languages').pluck(:name).sort)
+          .to include('go', 'ruby')
+      end
+    end
   end
 
   describe 'find or create by name' do


### PR DESCRIPTION
This PR contains a minor change to `for_context` that allow multiple values to be provided. When multiple values are provided, it uses an `IN` clause.