### PR TITLE
attribute_changed? ins deprecated as of Rails 5.1

### DIFF
--- a/lib/acts_as_taggable_on/taggable/dirty.rb
+++ b/lib/acts_as_taggable_on/taggable/dirty.rb
@@ -13,19 +13,20 @@ module ActsAsTaggableOn::Taggable
 
           class_eval <<-RUBY, __FILE__, __LINE__ + 1
             def #{tag_type}_list_changed?
-              changed_attributes.include?("#{tag_type}_list")
+              @changed_attributes && @changed_attributes.include?("#{tag_type}_list")
             end
+            alias_method :will_save_change_to_#{tag_type}_list?, :#{tag_type}_list_changed?
 
             def #{tag_type}_list_was
-              changed_attributes.include?("#{tag_type}_list") ? changed_attributes["#{tag_type}_list"] : __send__("#{tag_type}_list")
+              @changed_attributes && @changed_attributes.include?("#{tag_type}_list") ? @changed_attributes["#{tag_type}_list"] : __send__("#{tag_type}_list")
             end
 
             def #{tag_type}_list_change
-              [changed_attributes['#{tag_type}_list'], __send__('#{tag_type}_list')] if changed_attributes.include?("#{tag_type}_list")
+              [@changed_attributes['#{tag_type}_list'], __send__('#{tag_type}_list')] if @changed_attributes && @changed_attributes.include?("#{tag_type}_list")
             end
 
             def #{tag_type}_list_changes
-              [changed_attributes['#{tag_type}_list'], __send__('#{tag_type}_list')] if changed_attributes.include?("#{tag_type}_list")
+              [@changed_attributes['#{tag_type}_list'], __send__('#{tag_type}_list')] if @changed_attributes && @changed_attributes.include?("#{tag_type}_list")
             end
           RUBY
 

--- a/spec/acts_as_taggable_on/taggable/dirty_spec.rb
+++ b/spec/acts_as_taggable_on/taggable/dirty_spec.rb
@@ -19,6 +19,7 @@ describe ActsAsTaggableOn::Taggable::Dirty do
 
       it 'flags tag_list as changed' do
         expect(@taggable.tag_list_changed?).to be_truthy
+        expect(@taggable.will_save_change_to_tag_list?).to be_truthy
       end
 
       it 'preserves original value' do


### PR DESCRIPTION
`attribute_changed?` is now deprecated and replaced by `will_save_change_to_attribute?`

Also, caling `changed_attributes` method generates a deprecation warning.