### PR TITLE
Fix tagged_with matching wrong contexts

### DIFF
--- a/lib/acts_as_taggable_on/taggable/tagged_with_query/all_tags_query.rb
+++ b/lib/acts_as_taggable_on/taggable/tagged_with_query/all_tags_query.rb
@@ -49,7 +49,7 @@ module ActsAsTaggableOn::Taggable::TaggedWithQuery
       end
 
       if options[:on].present?
-        on_condition = on_condition.and(tagging_alias[:context].lteq(options[:on]))
+        on_condition = on_condition.and(tagging_alias[:context].eq(options[:on]))
       end
 
       if (owner = options[:owned_by]).present?
@@ -75,7 +75,7 @@ module ActsAsTaggableOn::Taggable::TaggedWithQuery
       end
 
       if options[:on].present?
-        on_condition = on_condition.and(tagging_arel_table[:context].lteq(options[:on]))
+        on_condition = on_condition.and(tagging_arel_table[:context].eq(options[:on]))
       end
 
       on_condition

--- a/lib/acts_as_taggable_on/taggable/tagged_with_query/any_tags_query.rb
+++ b/lib/acts_as_taggable_on/taggable/tagged_with_query/any_tags_query.rb
@@ -38,7 +38,7 @@ module ActsAsTaggableOn::Taggable::TaggedWithQuery
       end
 
       if options[:on].present?
-        exists_contition = exists_contition.and(tagging_arel_table[:context].lteq(options[:on]))
+        exists_contition = exists_contition.and(tagging_arel_table[:context].eq(options[:on]))
       end
 
       if (owner = options[:owned_by]).present?

--- a/lib/acts_as_taggable_on/taggable/tagged_with_query/exclude_tags_query.rb
+++ b/lib/acts_as_taggable_on/taggable/tagged_with_query/exclude_tags_query.rb
@@ -63,7 +63,7 @@ module ActsAsTaggableOn::Taggable::TaggedWithQuery
       end
 
       if options[:on].present?
-        on_condition = on_condition.and(tagging_arel_table[:context].lteq(options[:on]))
+        on_condition = on_condition.and(tagging_arel_table[:context].eq(options[:on]))
       end
 
       on_condition

--- a/spec/acts_as_taggable_on/taggable_spec.rb
+++ b/spec/acts_as_taggable_on/taggable_spec.rb
@@ -215,6 +215,14 @@ describe 'Taggable' do
 
     expect(TaggableModel.tagged_with('ruby').first).to eq(@taggable)
   end
+  
+  it 'should be able to find by tag in a particular context' do
+    @taggable.skill_list = 'ruby'
+    @taggable.save
+
+    expect(TaggableModel.tagged_with('ruby', on: :tags)).to eq([])
+    expect(TaggableModel.tagged_with('ruby', on: :skills).first).to eq(@taggable)
+  end
 
   it 'should be able to get a count with find by tag when using a group by' do
     @taggable.skill_list = 'ruby'


### PR DESCRIPTION
I think tagged_with has a context-matching bug since the rewrite.  Given three tag-contexts, "apple", "banana", and "candy", `tagged_with("foo", on: "banana")` can return taggables that are in tag-contexts of "apple" or "banana".

It's matching all taggings where `context <= "banana"`, rather than where `context = "banana"`.
I'm guessing this is a copy-paste typo (/cc @rbritom, @seuros ?)