### PR TITLE
fix dirty behaviour for items with persisted taggings

### DIFF
--- a/spec/acts_as_taggable_on/taggable/dirty_spec.rb
+++ b/spec/acts_as_taggable_on/taggable/dirty_spec.rb
@@ -45,6 +45,18 @@ describe ActsAsTaggableOn::Taggable::Dirty do
           expect(taggable.tag_list_changed?).to be_truthy
         end
       end
+
+      context 'with existing tags when reloaded' do
+        before do
+          @taggable = TaggableModel.find(@taggable.id)
+          expect(@taggable.changes).to be_empty
+          @taggable.tag_list = 'one'
+        end
+
+        it 'flags tag_list as changed' do
+          expect(@taggable.tag_list_changed?).to be_truthy
+        end
+      end
     end
 
     context 'when tag_list is the same' do


### PR DESCRIPTION
Fixes #811. 

If item contains persisted taggings dirty methods will not work for the newly instantiated object:
```
item = Item.create(tag_list: 'a')
item = Item.find(item.id)
item.tag_list = 'b, c'
item.tag_list_changed? # => false
```

Root cause of this is the `custom_contexts` method returning all taggings contexts instead of only the custom ones, in result the `process_dirty_object` method is not called if any persisted tagging exist for the item for that context

this is similar to #723 and #728 but based on the current codebase and only addressing this specific issue with minimal impact to other/unrelated functionalities. The `custom_contexts` method is only used as a guard for process_dirty_object and preventing duplicates in `add_custom_context` and this behaviour is not affected, so this should be safe to merge

**NOTE:** the failures in Travis build are not related - it should all pass after #880 is merged