### PR TITLE
add version requirement for pg gem to address rails/rails#31671

### DIFF
--- a/acts-as-taggable-on.gemspec
+++ b/acts-as-taggable-on.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency 'sqlite3'
   gem.add_development_dependency 'mysql2', '~> 0.3'
-  gem.add_development_dependency 'pg'
+  gem.add_development_dependency 'pg', '~> 0.18'
 
   gem.add_development_dependency 'rspec-rails'
   gem.add_development_dependency 'rspec-its'


### PR DESCRIPTION
add version requirement for pg gem - fixes postgres builds currently failing because of https://github.com/rails/rails/pull/31671