### PR TITLE
improve postgres escape sequence

### DIFF
--- a/lib/acts_as_taggable_on/taggable/tagged_with_query/query_base.rb
+++ b/lib/acts_as_taggable_on/taggable/tagged_with_query/query_base.rb
@@ -48,7 +48,7 @@ module ActsAsTaggableOn::Taggable::TaggedWithQuery
 
     def escaped_tag(tag)
       tag = tag.downcase unless ActsAsTaggableOn.strict_case_match
-      tag.gsub(/[!%_]/) { |x| '!' + x }
+      ActsAsTaggableOn::Utils.escape_like(tag)
     end
 
     def adjust_taggings_alias(taggings_alias)

--- a/lib/acts_as_taggable_on/utils.rb
+++ b/lib/acts_as_taggable_on/utils.rb
@@ -30,7 +30,11 @@ module ActsAsTaggableOn
 
       # escape _ and % characters in strings, since these are wildcards in SQL.
       def escape_like(str)
-        str.gsub(/[!%_]/) { |x| '!' + x }
+        str.gsub(/[!%_]/) { |x| escape_replacement + x }
+      end
+
+      def escape_replacement
+        using_postgresql? ? '\\' : '!'
       end
     end
   end

--- a/spec/acts_as_taggable_on/utils_spec.rb
+++ b/spec/acts_as_taggable_on/utils_spec.rb
@@ -20,4 +20,16 @@ describe ActsAsTaggableOn::Utils do
       expect(ActsAsTaggableOn::Utils.sha_prefix('puppies')).not_to eq(ActsAsTaggableOn::Utils.sha_prefix('kittens'))
     end
   end
+
+  describe '#escape_replacement' do
+    it 'should return ! when the adapter is not PostgreSQL' do
+      allow(ActsAsTaggableOn::Utils.connection).to receive(:adapter_name) { 'MySQL' }
+      expect(ActsAsTaggableOn::Utils.escape_replacement).to eq('!')
+    end
+
+    it 'should return \\ when the adapter is PostgreSQL' do
+      allow(ActsAsTaggableOn::Utils.connection).to receive(:adapter_name) { 'PostgreSQL' }
+      expect(ActsAsTaggableOn::Utils.escape_replacement).to eq('\\')
+    end
+  end
 end


### PR DESCRIPTION
Fixes https://github.com/mbleigh/acts-as-taggable-on/issues/864

I'm not sure why ActsAsTaggableOn::Utils#escape_like is named specifically for like when it seems to be generic escape functionality. wondering if this should be renamed to just escape?

Also, unsure about add myself to CHANGELOG.md and documenting this change since all the entries seem to be tied to a gem version. Is this no longer the practice? Could not see this in other recent PR as well.

Thanks and sorry for all the questions heh.