### PR TITLE
Fix ActiveRecord::StatementInvalid error when using UUID as primary key

### DIFF
--- a/lib/acts_as_taggable_on/taggable/related.rb
+++ b/lib/acts_as_taggable_on/taggable/related.rb
@@ -49,7 +49,7 @@ module ActsAsTaggableOn::Taggable
     private
 
     def exclude_self(klass, id)
-      "#{klass.table_name}.#{klass.primary_key} != #{id} AND" if [self.class.base_class, self.class].include? klass
+      "#{klass.arel_table[klass.primary_key].not_eq(id).to_sql} AND" if [self.class.base_class, self.class].include? klass
     end
 
     def group_columns(klass)

--- a/spec/acts_as_taggable_on/related_spec.rb
+++ b/spec/acts_as_taggable_on/related_spec.rb
@@ -33,6 +33,15 @@ describe 'Acts As Taggable On' do
       expect(taggable1.find_related_tags).to_not include(taggable2)
     end
 
+    it 'should find related objects based on tag names on context - uuid primary key' do
+      taggable1 = TaggableModelWithUuidPrimaryKey.create!(name: 'Taggable 1',tag_list: 'one, two')
+      taggable2 = TaggableModelWithUuidPrimaryKey.create!(name: 'Taggable 2',tag_list: 'three, four')
+      taggable3 = TaggableModelWithUuidPrimaryKey.create!(name: 'Taggable 3',tag_list: 'one, four')
+
+      expect(taggable1.find_related_tags).to include(taggable3)
+      expect(taggable1.find_related_tags).to_not include(taggable2)
+    end
+
     it 'should find other related objects based on tag names on context' do
       taggable1 = TaggableModel.create!(name: 'Taggable 1',tag_list: 'one, two')
       taggable2 = OtherTaggableModel.create!(name: 'Taggable 2',tag_list: 'three, four')

--- a/spec/internal/app/models/models.rb
+++ b/spec/internal/app/models/models.rb
@@ -72,6 +72,24 @@ class NonStandardIdTaggableModel < ActiveRecord::Base
   has_many :untaggable_models
 end
 
+class TaggableModelWithUuidPrimaryKey < ActiveRecord::Base
+  self.primary_key = 'id'
+  acts_as_taggable
+  acts_as_taggable_on :languages
+  acts_as_taggable_on :skills
+  acts_as_taggable_on :needs, :offerings
+  has_many :untaggable_models
+
+  before_create :assign_uuid
+
+  private
+
+  def assign_uuid
+    self.id = SecureRandom.uuid
+  end
+end
+
+
 class OrderedTaggableModel < ActiveRecord::Base
   acts_as_ordered_taggable
   acts_as_ordered_taggable_on :colours

--- a/spec/internal/app/models/taggable_model_with_uuid_primary_key.rb
+++ b/spec/internal/app/models/taggable_model_with_uuid_primary_key.rb
@@ -1,0 +1,16 @@
+class TaggableModelWithUuidPrimaryKey < ActiveRecord::Base
+  self.primary_key = 'id'
+  acts_as_taggable
+  acts_as_taggable_on :languages
+  acts_as_taggable_on :skills
+  acts_as_taggable_on :needs, :offerings
+  has_many :untaggable_models
+
+  before_create :assign_uuid
+
+  private
+
+  def assign_uuid
+    self.id = SecureRandom.uuid
+  end
+end

--- a/spec/internal/db/schema.rb
+++ b/spec/internal/db/schema.rb
@@ -41,6 +41,12 @@ ActiveRecord::Schema.define version: 0 do
     t.column :type, :string
   end
 
+  create_table :taggable_model_with_uuid_primary_keys, id: false, force: true do |t|
+    t.column :id, :string, null: false
+    t.column :name, :string
+    t.column :type, :string
+  end
+
   create_table :untaggable_models, force: true do |t|
     t.column :taggable_model_id, :integer
     t.column :name, :string


### PR DESCRIPTION
If using UUID as primary key, the relationships feature raises `ActiveRecord::StatementInvalid` error when you try something like:

```
User.first.find_related_skills
```

```
ActiveRecord::StatementInvalid: PG::SyntaxError: ERROR:  syntax error at or near "a56f2e"
LINE 1: ...w FROM users, tags, taggings WHERE (users.id != 96a56f2e-393...
                                                             ^
```