### PR TITLE
fix camelCase column lead to exception when query

### DIFF
--- a/lib/acts_as_taggable_on/taggable/core.rb
+++ b/lib/acts_as_taggable_on/taggable/core.rb
@@ -76,7 +76,7 @@ module ActsAsTaggableOn::Taggable
 
       # all column names are necessary for PostgreSQL group clause
       def grouped_column_names_for(object)
-        object.column_names.map { |column| "#{object.table_name}.#{column}" }.join(', ')
+        object.column_names.map { |column| "#{object.table_name}.\"#{column}\"" }.join(', ')
       end
 
       ##


### PR DESCRIPTION
when the pg database have column, like `firstName`, the original code would throw exception.

need add quote for the column names