### PR TITLE
We only need to join on the taggable's table if using STI

### DIFF
--- a/lib/acts_as_taggable_on/taggable/collection.rb
+++ b/lib/acts_as_taggable_on/taggable/collection.rb
@@ -94,16 +94,18 @@ module ActsAsTaggableOn::Taggable
         ## Generate conditions:
         options[:conditions] = sanitize_sql(options[:conditions]) if options[:conditions]
 
-        ## Generate joins:
-        taggable_join = "INNER JOIN #{table_name} ON #{table_name}.#{primary_key} = #{ActsAsTaggableOn::Tagging.table_name}.taggable_id"
-        taggable_join << " AND #{table_name}.#{inheritance_column} = '#{name}'" unless descends_from_active_record? # Current model is STI descendant, so add type checking to the join condition
-
         ## Generate scope:
         tagging_scope = ActsAsTaggableOn::Tagging.select("#{ActsAsTaggableOn::Tagging.table_name}.tag_id, COUNT(#{ActsAsTaggableOn::Tagging.table_name}.tag_id) AS tags_count")
         tag_scope = ActsAsTaggableOn::Tag.select("#{ActsAsTaggableOn::Tag.table_name}.*, #{ActsAsTaggableOn::Tagging.table_name}.tags_count AS count").order(options[:order]).limit(options[:limit])
 
-        # Joins and conditions
-        tagging_scope = tagging_scope.joins(taggable_join)
+        # Current model is STI descendant, so add type checking to the join condition
+        unless descends_from_active_record?
+          taggable_join = "INNER JOIN #{table_name} ON #{table_name}.#{primary_key} = #{ActsAsTaggableOn::Tagging.table_name}.taggable_id"
+          taggable_join << " AND #{table_name}.#{inheritance_column} = '#{name}'"
+          tagging_scope = tagging_scope.joins(taggable_join)
+        end
+
+        # Conditions
         tagging_conditions(options).each { |condition| tagging_scope = tagging_scope.where(condition) }
         tag_scope = tag_scope.where(options[:conditions])
 


### PR DESCRIPTION
The INNER JOIN on the taggable's table name is only necessary if the taggable is using single table inheritance. Otherwise, the IN subquery generated in `generate_tagging_scope_in_clause`, which retrieves a list of the taggable's IDs based on the current scope, is sufficient. `tagging_conditions` also already includes making sure that taggable_type is the one that corresponds to the taggable.

The removal of the extra inner join in non-STI cases improves performance quite significantly for tag counts.

Take into consideration `Project.tag_counts_on(:tags)`, and `Project.where("client is not null").tag_counts_on(:tag)`

Current:
```
SELECT  tags.*, taggings.tags_count AS count 
FROM "tags" 
JOIN (
  SELECT taggings.tag_id, COUNT(taggings.tag_id) AS tags_count 
  FROM "taggings" 
  INNER JOIN projects ON projects.id = taggings.taggable_id 
  WHERE (taggings.taggable_type = 'Project' AND taggings.context = 'tags') 
  AND (taggings.taggable_id IN(
    SELECT projects.id FROM "projects"
  )) 
  GROUP BY taggings.tag_id 
  HAVING COUNT(taggings.tag_id) > 0
) AS taggings ON taggings.tag_id = tags.id

SELECT  tags.*, taggings.tags_count AS count 
FROM "tags" 
JOIN (
  SELECT taggings.tag_id, COUNT(taggings.tag_id) AS tags_count 
  FROM "taggings" 
  INNER JOIN projects ON projects.id = taggings.taggable_id 
  WHERE (taggings.taggable_type = 'Project' AND taggings.context = 'tags') 
  AND (taggings.taggable_id IN(
    SELECT projects.id FROM "projects" where client is not null
  )) 
  GROUP BY taggings.tag_id 
  HAVING COUNT(taggings.tag_id) > 0
) AS taggings ON taggings.tag_id = tags.id
```

With this change:
```
SELECT  tags.*, taggings.tags_count AS count 
FROM "tags" 
JOIN (
  SELECT taggings.tag_id, COUNT(taggings.tag_id) AS tags_count 
  FROM "taggings"
  WHERE (taggings.taggable_type = 'Project' AND taggings.context = 'tags') 
  AND (taggings.taggable_id IN(
    SELECT projects.id FROM "projects"
  )) 
  GROUP BY taggings.tag_id 
  HAVING COUNT(taggings.tag_id) > 0
) AS taggings ON taggings.tag_id = tags.id

SELECT  tags.*, taggings.tags_count AS count 
FROM "tags" 
JOIN (
  SELECT taggings.tag_id, COUNT(taggings.tag_id) AS tags_count 
  FROM "taggings" 
  WHERE (taggings.taggable_type = 'Project' AND taggings.context = 'tags') 
  AND (taggings.taggable_id IN(
    SELECT projects.id FROM "projects" where client is not null
  )) 
  GROUP BY taggings.tag_id 
  HAVING COUNT(taggings.tag_id) > 0
) AS taggings ON taggings.tag_id = tags.id
```

Fixes #724 