### PR TITLE
Use none instead of false query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Each change should fall into categories that would affect whether the release is
 
 As such, a _Feature_ would map to either major or minor. A _bug fix_ to a patch.  And _misc_ is either minor or patch, the difference being kind of fuzzy for the purposes of history.  Adding tests would be patch level.
 
+### [Master / Unreleased](https://github.com/mbleigh/acts-as-taggable-on/compare/v6.0.1...master)
+  * Misc
+    * [@gssbzn Remove legacy code for an empty query and replace it with ` ActiveRecord::none`](https://github.com/mbleigh/acts-as-taggable-on/pull/906)
+
 ### [6.0.1 / 2018-06-27](https://github.com/mbleigh/acts-as-taggable-on/compare/v6.0.0...v6.0.1)
   * Fixes
     * [@hengwoon tags_count only need to join on the taggable's table if using STI ](https://github.com/mbleigh/acts-as-taggable-on/pull/904)

--- a/lib/acts_as_taggable_on/taggable/core.rb
+++ b/lib/acts_as_taggable_on/taggable/core.rb
@@ -103,9 +103,8 @@ module ActsAsTaggableOn::Taggable
       def tagged_with(tags, options = {})
         tag_list = ActsAsTaggableOn.default_parser.new(tags).parse
         options = options.dup
-        empty_result = where('1 = 0')
 
-        return empty_result if tag_list.empty?
+        return none if tag_list.empty?
 
         ::ActsAsTaggableOn::Taggable::TaggedWithQuery.build(self, ActsAsTaggableOn::Tag, ActsAsTaggableOn::Tagging, tag_list, options)
       end


### PR DESCRIPTION
None allows the use a null object pattern, this prevent doing further queries to the database knowing they'll always return false

Originally
```ruby
posts = Post.tagged_with.recent
```
Would still generate queries to the database
with this change Rails would always return a chainable NullObject that avoids doing further queries tothe database