### PR TITLE
Scope tags for taggable type

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,10 @@ source 'https://rubygems.org'
 
 gemspec
 
+group :test do
+  gem 'sqlite3'
+end
+
 group :local_development do
   gem 'guard'
   gem 'guard-rspec'

--- a/Gemfile
+++ b/Gemfile
@@ -2,10 +2,6 @@ source 'https://rubygems.org'
 
 gemspec
 
-group :test do
-  gem 'sqlite3'
-end
-
 group :local_development do
   gem 'guard'
   gem 'guard-rspec'

--- a/lib/acts_as_taggable_on/tag.rb
+++ b/lib/acts_as_taggable_on/tag.rb
@@ -21,7 +21,7 @@ module ActsAsTaggableOn
     ### SCOPES:
     scope :most_used, ->(limit = 20) { order('taggings_count desc').limit(limit) }
     scope :least_used, ->(limit = 20) { order('taggings_count asc').limit(limit) }
-    scope :for_taggable_type, -> (type = nil) { joins(:taggings).where('taggings.taggable_type' => type.to_s) }
+    scope :for_taggable_type, -> (type = nil) { joins(:taggings).where('taggings.taggable_type' => Array.wrap(type)) }
 
     def self.named(name)
       if ActsAsTaggableOn.strict_case_match

--- a/lib/acts_as_taggable_on/tag.rb
+++ b/lib/acts_as_taggable_on/tag.rb
@@ -21,7 +21,7 @@ module ActsAsTaggableOn
     ### SCOPES:
     scope :most_used, ->(limit = 20) { order('taggings_count desc').limit(limit) }
     scope :least_used, ->(limit = 20) { order('taggings_count asc').limit(limit) }
-    scope :for_taggable_type, -> (type = nil) { joins(:taggings).where('taggings.taggable_type' => type) }
+    scope :for_taggable_type, -> (type = nil) { joins(:taggings).where('taggings.taggable_type' => type.to_s) }
 
     def self.named(name)
       if ActsAsTaggableOn.strict_case_match

--- a/lib/acts_as_taggable_on/tag.rb
+++ b/lib/acts_as_taggable_on/tag.rb
@@ -21,6 +21,7 @@ module ActsAsTaggableOn
     ### SCOPES:
     scope :most_used, ->(limit = 20) { order('taggings_count desc').limit(limit) }
     scope :least_used, ->(limit = 20) { order('taggings_count asc').limit(limit) }
+    scope :for_taggable_type, -> (type = nil) { joins(:taggings).where('taggings.taggable_type' => type) }
 
     def self.named(name)
       if ActsAsTaggableOn.strict_case_match

--- a/lib/acts_as_taggable_on/version.rb
+++ b/lib/acts_as_taggable_on/version.rb
@@ -1,3 +1,3 @@
 module ActsAsTaggableOn
-  VERSION = '6.0.1'
+  VERSION = '6.0.2'
 end

--- a/spec/acts_as_taggable_on/tag_spec.rb
+++ b/spec/acts_as_taggable_on/tag_spec.rb
@@ -16,7 +16,29 @@ describe ActsAsTaggableOn::Tag do
     @tag = ActsAsTaggableOn::Tag.new
     @user = TaggableModel.create(name: 'Pablo')
   end
-
+  
+  
+  # scopes
+  describe 'for_taggable_type' do
+    before(:each) do
+      @tag_1 = ActsAsTaggableOn::Tag.create(name: 'Awesome')
+      @tag_2 = ActsAsTaggableOn::Tag.create(name: 'notSoCool')
+      @tagging_1 = ActsAsTaggableOn::Tagging.create(taggable: @user, tag: @tag_1, context: 'tags')
+      @tagging_2 = ActsAsTaggableOn::Tagging.create(taggable_type: 'AnyClass', taggable_id: 1, tag: @tag_2, context: 'tags')
+      # this one is not to be found...
+      @tagging_3 = ActsAsTaggableOn::Tagging.create(taggable_type: 'DontCare', taggable_id: 1, tag: @tag_2, context: 'tags')
+    end
+    
+    specify "finds one given taggable type" do
+      expect(ActsAsTaggableOn::Tag.for_taggable_type(TaggableModel.to_s)).to match_array([@tag_1])
+    end
+    
+    specify "finds multiple give taggable type" do
+      expect(ActsAsTaggableOn::Tag.for_taggable_type([TaggableModel.to_s, @tagging_2.taggable_type])).to match_array([@tag_1, @tag_2])
+    end
+    
+    
+  end
 
   describe 'named like any' do
     context 'case insensitive collation and unique index on tag name', if: using_case_insensitive_collation? do


### PR DESCRIPTION
just realized when suggesting autocomplete for tags to users, i cant show tags only for a certain `taggable_type`
(maybe i missed it in the code though) - if not here is a patch for that situation.

in may case - tags are totally different depending on the class the are assigned to. now i can filter for that as well.