### PR TITLE
Set belongs_to as optional to get around new Rails 5.2 presence enforcement

### DIFF
--- a/lib/acts_as_taggable_on/tagging.rb
+++ b/lib/acts_as_taggable_on/tagging.rb
@@ -4,7 +4,7 @@ module ActsAsTaggableOn
 
     DEFAULT_CONTEXT = 'tags'
     belongs_to :tag, class_name: '::ActsAsTaggableOn::Tag', counter_cache: ActsAsTaggableOn.tags_counter
-    belongs_to :taggable, polymorphic: true
+    belongs_to :taggable, polymorphic: true, optional: true
 
     belongs_to :tagger, {polymorphic: true}.tap {|o| o.merge!(optional: true) }
 


### PR DESCRIPTION
Without this simple change, we get problems with creating tags as part of a record creation, rather than adding them afterwards.