### PR TITLE
Fix caching on first save for an unused model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ As such, _Breaking Changes_ are major. _Features_ would map to either major or m
   * [@mizukami234 @junmoka Make table names configurable](https://github.com/mbleigh/acts-as-taggable-on/pull/910)
 * Fixes
   * [@tonyta Avoid overriding user-defined columns cache methods](https://github.com/mbleigh/acts-as-taggable-on/pull/911)
+  * [@kratob Fix caching on first save for an unused model](https://github.com/mbleigh/acts-as-taggable-on/pull/928)
 * Misc
   * [@gssbzn Remove legacy code for an empty query and replace it with ` ActiveRecord::none`](https://github.com/mbleigh/acts-as-taggable-on/pull/906)
 * Documentation

--- a/lib/acts_as_taggable_on/taggable/cache.rb
+++ b/lib/acts_as_taggable_on/taggable/cache.rb
@@ -3,40 +3,28 @@ module ActsAsTaggableOn::Taggable
     def self.included(base)
       # When included, conditionally adds tag caching methods when the model
       #   has any "cached_#{tag_type}_list" column
-      base.extend Columns
+      base.extend LoadSchema
     end
 
-    module Columns
-      # ActiveRecord::Base.columns makes a database connection and caches the
-      #   calculated columns hash for the record as @columns.  Since we don't
-      #   want to add caching methods until we confirm the presence of a
-      #   caching column, and we don't want to force opening a database
-      #   connection when the class is loaded, here we intercept and cache
-      #   the call to :columns as @acts_as_taggable_on_cache_columns
-      #   to mimic the underlying behavior.  While processing this first
-      #   call to columns, we do the caching column check and dynamically add
-      #   the class and instance methods
-      #   FIXME: this method cannot compile in rubinius
-      def columns
-        @acts_as_taggable_on_cache_columns ||= begin
-          db_columns = super
-          _add_tags_caching_methods if _has_tags_cache_columns?(db_columns)
-          db_columns
-        end
-      end
-
-      def reset_column_information
-        super
-        @acts_as_taggable_on_cache_columns = nil
-      end
-
+    module LoadSchema
       private
 
       # @private
-      def _has_tags_cache_columns?(db_columns)
-        db_column_names = db_columns.map(&:name)
+      # ActiveRecord::Base.load_schema! makes a database connection and caches the
+      #   calculated columns hash for the record as @column_hashs. Since we don't
+      #   want to add caching methods until we confirm the presence of a
+      #   caching column, and we don't want to force opening a database connection,
+      #   we override load_schema!, do the caching column check and dynamically
+      #   add the class and instance methods.
+      def load_schema!
+        super
+        _add_tags_caching_methods if _has_tags_cache_columns?
+      end
+
+      # @private
+      def _has_tags_cache_columns?
         tag_types.any? do |context|
-          db_column_names.include?("cached_#{context.to_s.singularize}_list")
+          @columns_hash.has_key?("cached_#{context.to_s.singularize}_list")
         end
       end
 

--- a/spec/acts_as_taggable_on/caching_spec.rb
+++ b/spec/acts_as_taggable_on/caching_spec.rb
@@ -38,6 +38,14 @@ describe 'Acts As Taggable On' do
       expect(@another_taggable.cached_language_list).to eq('ruby, .net')
     end
 
+    it 'should cache tags when the model is freshly loaded' do
+      taggable = SingleUseCachedModel.new
+      taggable.tag_list = 'awesome, epic'
+      taggable.save!
+
+      expect(taggable.cached_tag_list).to eq('awesome, epic')
+    end
+
     it 'should keep the cache' do
       @taggable.update_attributes(tag_list: 'awesome, epic')
       @taggable = CachedModel.find(@taggable.id)

--- a/spec/internal/app/models/single_use_cached_model.rb
+++ b/spec/internal/app/models/single_use_cached_model.rb
@@ -1,0 +1,5 @@
+# This is used in a spec that expects this model not to have been used before.
+class SingleUseCachedModel < ActiveRecord::Base
+  self.table_name = 'cached_models'
+  acts_as_taggable
+end


### PR DESCRIPTION
On certain code paths, saving an instance of a model for the first time can cause the cache column not to be written. Affected code looks like this:

```
class Model < ActiveRecord::Base
  acts_as_taggable_on
end

record = Model.new
record.tag_list = 'foo, 'bar'
record.save!
record.tag_list   # => nil
```

The reason for this is that the `after_save` hook gets dynamically added when calling `Model.columns`. However, `Model.new` does not actually do that.

The fix uses `Model.load_schema!` instead.