### PR TITLE
use ActiveRecord::Migration version 5.0 or 5.1 instead of 4.2

### DIFF
--- a/db/migrate/1_acts_as_taggable_on_migration.rb
+++ b/db/migrate/1_acts_as_taggable_on_migration.rb
@@ -1,7 +1,7 @@
-if ActiveRecord.gem_version >= Gem::Version.new('5.0')
-  class ActsAsTaggableOnMigration < ActiveRecord::Migration[4.2]; end
+if ActiveRecord.gem_version >= Gem::Version.new('5.1')
+  class ActsAsTaggableOnMigration < ActiveRecord::Migration[5.1]; end
 else
-  class ActsAsTaggableOnMigration < ActiveRecord::Migration; end
+  class ActsAsTaggableOnMigration < ActiveRecord::Migration[5.0]; end
 end
 ActsAsTaggableOnMigration.class_eval do
   def self.up
@@ -11,12 +11,12 @@ ActsAsTaggableOnMigration.class_eval do
     end
 
     create_table ActsAsTaggableOn.taggings_table do |t|
-      t.references :tag, foreign_key: { to_table: ActsAsTaggableOn.tags_table }
+      t.references :tag, foreign_key: { to_table: ActsAsTaggableOn.tags_table }, index: false
 
       # You should make sure that the column created is
       # long enough to store the required class names.
-      t.references :taggable, polymorphic: true
-      t.references :tagger, polymorphic: true
+      t.references :taggable, polymorphic: true, index: false
+      t.references :tagger, polymorphic: true, index: false
 
       # Limit is created to prevent MySQL error on index
       # length for MyISAM table type: http://bit.ly/vgW2Ql

--- a/db/migrate/2_add_missing_unique_indices.rb
+++ b/db/migrate/2_add_missing_unique_indices.rb
@@ -1,7 +1,7 @@
-if ActiveRecord.gem_version >= Gem::Version.new('5.0')
-  class AddMissingUniqueIndices < ActiveRecord::Migration[4.2]; end
+if ActiveRecord.gem_version >= Gem::Version.new('5.1')
+  class AddMissingUniqueIndices < ActiveRecord::Migration[5.1]; end
 else
-  class AddMissingUniqueIndices < ActiveRecord::Migration; end
+  class AddMissingUniqueIndices < ActiveRecord::Migration[5.0]; end
 end
 AddMissingUniqueIndices.class_eval do
   def self.up

--- a/db/migrate/3_add_taggings_counter_cache_to_tags.rb
+++ b/db/migrate/3_add_taggings_counter_cache_to_tags.rb
@@ -1,7 +1,7 @@
-if ActiveRecord.gem_version >= Gem::Version.new('5.0')
-  class AddTaggingsCounterCacheToTags < ActiveRecord::Migration[4.2]; end
+if ActiveRecord.gem_version >= Gem::Version.new('5.1')
+  class AddTaggingsCounterCacheToTags < ActiveRecord::Migration[5.1]; end
 else
-  class AddTaggingsCounterCacheToTags < ActiveRecord::Migration; end
+  class AddTaggingsCounterCacheToTags < ActiveRecord::Migration[5.0]; end
 end
 AddTaggingsCounterCacheToTags.class_eval do
   def self.up

--- a/db/migrate/4_add_missing_taggable_index.rb
+++ b/db/migrate/4_add_missing_taggable_index.rb
@@ -1,7 +1,7 @@
-if ActiveRecord.gem_version >= Gem::Version.new('5.0')
-  class AddMissingTaggableIndex < ActiveRecord::Migration[4.2]; end
+if ActiveRecord.gem_version >= Gem::Version.new('5.1')
+  class AddMissingTaggableIndex < ActiveRecord::Migration[5.1]; end
 else
-  class AddMissingTaggableIndex < ActiveRecord::Migration; end
+  class AddMissingTaggableIndex < ActiveRecord::Migration[5.0]; end
 end
 AddMissingTaggableIndex.class_eval do
   def self.up

--- a/db/migrate/5_change_collation_for_tag_names.rb
+++ b/db/migrate/5_change_collation_for_tag_names.rb
@@ -1,9 +1,9 @@
 # This migration is added to circumvent issue #623 and have special characters
 # work properly
-if ActiveRecord.gem_version >= Gem::Version.new('5.0')
-  class ChangeCollationForTagNames < ActiveRecord::Migration[4.2]; end
+if ActiveRecord.gem_version >= Gem::Version.new('5.1')
+  class ChangeCollationForTagNames < ActiveRecord::Migration[5.1]; end
 else
-  class ChangeCollationForTagNames < ActiveRecord::Migration; end
+  class ChangeCollationForTagNames < ActiveRecord::Migration[5.0]; end
 end
 ChangeCollationForTagNames.class_eval do
   def up

--- a/db/migrate/6_add_missing_indexes_on_taggings.rb
+++ b/db/migrate/6_add_missing_indexes_on_taggings.rb
@@ -1,7 +1,7 @@
-if ActiveRecord.gem_version >= Gem::Version.new('5.0')
-  class AddMissingIndexesOnTaggings < ActiveRecord::Migration[4.2]; end
+if ActiveRecord.gem_version >= Gem::Version.new('5.1')
+  class AddMissingIndexesOnTaggings < ActiveRecord::Migration[5.1]; end
 else
-  class AddMissingIndexesOnTaggings < ActiveRecord::Migration; end
+  class AddMissingIndexesOnTaggings < ActiveRecord::Migration[5.0]; end
 end
 AddMissingIndexesOnTaggings.class_eval do
   def change


### PR DESCRIPTION
## Why

1. Since this gem is dropping support for Rails 4.2 (#887), there is no reason to use `ActiveRecord::Migration[4.2]` as default migration version, sooner we migrate to 5 better
2. In Rails version > 5.1, default type of primary key becomes `bigint`, use `ActiveRecord::Migration[5.1]` can also help us adapt this change, make it more consistent

## Notable point

1. In Rails version > 5, migration method `t.references` will add index automatically, to keep migration result consistent, I add `index: false` for `tag`, `taggable `, `tagger` to prevent extra `index_taggings_on_taggable_type_and_taggable_id` and `index_taggings_on_tagger_type_and_tagger_id` index
2. After this change, if your ActiveRecord version > 5.1, all table's id will become `bigint` (if your database supports `bigint`)
