### PR TITLE
Add a test case for previous_changes

### DIFF
--- a/spec/acts_as_taggable_on/dirty_spec.rb
+++ b/spec/acts_as_taggable_on/dirty_spec.rb
@@ -37,6 +37,14 @@ describe 'Dirty behavior of taggable objects' do
         expect(@taggable.tag_list_change).to eq([['awesome', 'epic'], ['one']])
       end
 
+      it 'populates previous_changes correctly' do
+        @taggable.save!
+        @taggable.update!(tag_list: %w(two three four))
+
+        expect(@taggable.previous_changes['tag_list'])
+          .to eq([%w(one), %w(two three four)])
+      end
+
       context 'without order' do
         it 'should not mark attribute if order change ' do
           taggable = TaggableModel.create(name: 'Dirty Harry', tag_list: %w(d c b a))


### PR DESCRIPTION
This is attempting to reproduce an odd behavior we're seeing in GitLab at https://gitlab.com/gitlab-org/gitlab-ee/merge_requests/5107#note_122281994.

The problem we're seeing may be an odd interaction between ActiveRecord and some other gem we're using, but I want to first verify it's not an issue with acts-as-taggable-on itself.