### PR TITLE
fix association for tags counter_cache on migration

### DIFF
--- a/db/migrate/3_add_taggings_counter_cache_to_tags.rb
+++ b/db/migrate/3_add_taggings_counter_cache_to_tags.rb
@@ -9,7 +9,7 @@ AddTaggingsCounterCacheToTags.class_eval do
 
     ActsAsTaggableOn::Tag.reset_column_information
     ActsAsTaggableOn::Tag.find_each do |tag|
-      ActsAsTaggableOn::Tag.reset_counters(tag.id, ActsAsTaggableOn.taggings_table)
+      ActsAsTaggableOn::Tag.reset_counters(tag.id, :taggings)
     end
   end
 


### PR DESCRIPTION
Even if the taggings table name is changed, the association is still `taggings`