### PR TITLE
Specify bundler v 1.17.3 for travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ sudo: false
 bundler_args: '--without local_development --jobs 3 --retry 3'
 
 before_install:
-   - gem install bundler
+   - gem install bundler -v 1.17.3
 
 script: bundle exec rake
 


### PR DESCRIPTION
Since bundler version 2 will be installed by default if not otherwise specified, and since it precludes use of ruby < 2.3, we either need to stop testing ruby < 2.3, or require the use of an older bundler version. This is the most recent version prior to 2.x.