### PR TITLE
simplify relation options syntax

### DIFF
--- a/lib/acts_as_taggable_on/tagging.rb
+++ b/lib/acts_as_taggable_on/tagging.rb
@@ -6,7 +6,7 @@ module ActsAsTaggableOn
     belongs_to :tag, class_name: '::ActsAsTaggableOn::Tag', counter_cache: ActsAsTaggableOn.tags_counter
     belongs_to :taggable, polymorphic: true
 
-    belongs_to :tagger, {polymorphic: true}.tap {|o| o.merge!(optional: true) }
+    belongs_to :tagger, { polymorphic: true, optional: true }
 
     scope :owned_by, ->(owner) { where(tagger: owner) }
     scope :not_owned, -> { where(tagger_id: nil, tagger_type: nil) }


### PR DESCRIPTION
the current syntax is overcomplicated due to historical context, the updated version is equivalent