### PR TITLE
re-add sqlite to gemspec, update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -547,7 +547,7 @@ bundle
 rake spec
 ```
 
-You can run all the tests across all the Rails versions by running `rake appraise`.  If you'd also like to [run the tests across all rubies and databases as configured for Travis CI, install and run `wwtd`](https://github.com/grosser/wwtd).
+You can run all the tests across all the Rails versions by running `bundle exec appraisal install && bundle exec appraisal rspec`.  If you'd also like to [run the tests across all rubies and databases as configured for Travis CI, install and run `wwtd`](https://github.com/grosser/wwtd).
 
 
 ## License

--- a/acts-as-taggable-on.gemspec
+++ b/acts-as-taggable-on.gemspec
@@ -29,4 +29,5 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'rspec'
   gem.add_development_dependency 'barrier'
   gem.add_development_dependency 'database_cleaner'
+  gem.add_development_dependency 'sqlite3'
 end


### PR DESCRIPTION
- re-add sqlite to gemspec
   its' still needed to run tests without appraisal

- update appraisal instructions in the readme 
  the `rake appraise`tasks [has been removed a long time ago](https://github.com/mbleigh/acts-as-taggable-on/commit/830aabee46a9d40337b269425f368aeb17ffe06d#diff-52c976fc38ed2b4e3b1192f8a8e24cff)