### PR TITLE
Lock sqlite3 at ~> 1.3.6

### DIFF
--- a/acts-as-taggable-on.gemspec
+++ b/acts-as-taggable-on.gemspec
@@ -27,6 +27,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'rspec-rails'
   gem.add_development_dependency 'rspec-its'
   gem.add_development_dependency 'rspec'
+  gem.add_development_dependency 'sqlite3', '~> 1.3.6'
   gem.add_development_dependency 'barrier'
   gem.add_development_dependency 'database_cleaner'
 end


### PR DESCRIPTION
Fixes `can't activate sqlite3 (~> 1.3.6), already activated sqlite3-1.4.0` errors