### PR TITLE
Fix `Deprecate Unicode#downcase/upcase/swapcase.`

### DIFF
--- a/lib/acts_as_taggable_on/tag.rb
+++ b/lib/acts_as_taggable_on/tag.rb
@@ -123,7 +123,7 @@ module ActsAsTaggableOn
 
       def unicode_downcase(string)
         if ActiveSupport::Multibyte::Unicode.respond_to?(:downcase)
-          ActiveSupport::Multibyte::Unicode.downcase(string)
+          string.downcase
         else
           ActiveSupport::Multibyte::Chars.new(string).downcase.to_s
         end

--- a/lib/acts_as_taggable_on/taggable/core.rb
+++ b/lib/acts_as_taggable_on/taggable/core.rb
@@ -53,7 +53,7 @@ module ActsAsTaggableOn::Taggable
                 if Rails.version.to_f < 6.0
                   set_attribute_was('#{tag_type}_list', #{tag_type}_list)
                 else
-                  duplicated_mutations_from_database.change_to_attribute('#{tag_type}_list')
+                  d_mutations_from_database.change_to_attribute('#{tag_type}_list')
                 end
                 write_attribute("#{tag_type}_list", parsed_new_list)
               end
@@ -69,17 +69,6 @@ module ActsAsTaggableOn::Taggable
             def dirtify_tag_list(tagging)
               attribute_will_change! tagging.context.singularize+"_list"
             end
-              
-            def duplicated_mutations_from_database
-            unless defined?(@mutations_from_database)
-              @mutations_from_database = nil
-            end
-            @mutations_from_database ||= if defined?(@attributes)
-              ActiveModel::AttributeMutationTracker.new(@attributes)
-            else
-              NullMutationTracker.instance
-            end
-          end
           RUBY
         end
       end

--- a/lib/acts_as_taggable_on/taggable/core.rb
+++ b/lib/acts_as_taggable_on/taggable/core.rb
@@ -50,7 +50,11 @@ module ActsAsTaggableOn::Taggable
               parsed_new_list = ActsAsTaggableOn.default_parser.new(new_tags).parse
 
               if self.class.preserve_tag_order? || parsed_new_list.sort != #{tag_type}_list.sort
-                set_attribute_was('#{tag_type}_list', #{tag_type}_list)
+                if Rails.version.to_f < 6.0
+                  set_attribute_was('#{tag_type}_list', #{tag_type}_list)
+                else
+                  d_mutations_from_database.change_to_attribute('#{tag_type}_list')
+                end
                 write_attribute("#{tag_type}_list", parsed_new_list)
               end
 

--- a/lib/acts_as_taggable_on/taggable/core.rb
+++ b/lib/acts_as_taggable_on/taggable/core.rb
@@ -50,11 +50,7 @@ module ActsAsTaggableOn::Taggable
               parsed_new_list = ActsAsTaggableOn.default_parser.new(new_tags).parse
 
               if self.class.preserve_tag_order? || parsed_new_list.sort != #{tag_type}_list.sort
-                if Rails.version.to_f < 6.0
-                  set_attribute_was('#{tag_type}_list', #{tag_type}_list)
-                else
-                  d_mutations_from_database.change_to_attribute('#{tag_type}_list')
-                end
+                set_attribute_was('#{tag_type}_list', #{tag_type}_list)
                 write_attribute("#{tag_type}_list", parsed_new_list)
               end
 

--- a/lib/acts_as_taggable_on/taggable/core.rb
+++ b/lib/acts_as_taggable_on/taggable/core.rb
@@ -53,7 +53,7 @@ module ActsAsTaggableOn::Taggable
                 if Rails.version.to_f < 6.0
                   set_attribute_was('#{tag_type}_list', #{tag_type}_list)
                 else
-                  d_mutations_from_database.change_to_attribute('#{tag_type}_list')
+                  duplicated_mutations_from_database.change_to_attribute('#{tag_type}_list')
                 end
                 write_attribute("#{tag_type}_list", parsed_new_list)
               end
@@ -69,6 +69,17 @@ module ActsAsTaggableOn::Taggable
             def dirtify_tag_list(tagging)
               attribute_will_change! tagging.context.singularize+"_list"
             end
+              
+            def duplicated_mutations_from_database
+            unless defined?(@mutations_from_database)
+              @mutations_from_database = nil
+            end
+            @mutations_from_database ||= if defined?(@attributes)
+              ActiveModel::AttributeMutationTracker.new(@attributes)
+            else
+              NullMutationTracker.instance
+            end
+          end
           RUBY
         end
       end


### PR DESCRIPTION
```rb
DEPRECATION WARNING: ActiveSupport::Multibyte::Unicode#downcase is deprecated and will be removed from Rails 6.1. Use String methods directly. (called from unicode_downcase at /vendor/bundle/ruby/2.6.0/bundler/gems/acts-as-taggable-on-d01c315f616b/lib/acts_as_taggable_on/tag.rb:126)
```

ref rails/rails@619b2ae