### PR TITLE
Support Rails 6.0.0

### DIFF
--- a/gemfiles/activerecord_6.0.gemfile
+++ b/gemfiles/activerecord_6.0.gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "activerecord", "~> 6.0.0.beta1"
+gem "activerecord", "~> 6.0.0"
 case ENV["DB"]
 when "postgresql"
   gem 'pg'


### PR DESCRIPTION
This PR consists of removing ".beta1" from the gemfile, so it will install on Rails 6.0.0