### PR TITLE
Do not apply binary collation every time on rails boot for MySQL users

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ You can circumvent at any time the problem of special characters [issue 623](htt
 ActsAsTaggableOn.force_binary_collation = true
 ```
 
-Or by running this rake task:
+If `utf8_bin` collation is not aleady set on `name` column in your schema then make sure to set by re-running migration generator or run this rake task:
 
 ```shell
 rake acts_as_taggable_on_engine:tag_names:collate_bin

--- a/lib/acts-as-taggable-on.rb
+++ b/lib/acts-as-taggable-on.rb
@@ -102,7 +102,8 @@ WARNING
           @force_binary_collation = true
           @strict_case_match = true
         else
-          Configuration.apply_binary_collation(false)
+          # TODO: Add rake task to unset binary collation on db
+          # Configuration.apply_binary_collation(false)
           @force_binary_collation = false
         end
       end

--- a/lib/acts-as-taggable-on.rb
+++ b/lib/acts-as-taggable-on.rb
@@ -97,7 +97,8 @@ WARNING
     def force_binary_collation=(force_bin)
       if Utils.using_mysql?
         if force_bin
-          Configuration.apply_binary_collation(true)
+          # This script should be executed only once not every time when rails is booted.
+          # Configuration.apply_binary_collation(true)
           @force_binary_collation = true
           @strict_case_match = true
         else


### PR DESCRIPTION
Fixes #905 

**Background:**  To fix collation issue with MySQL we added
`ActsAsTaggableOn.force_binary_collation = true`

**Reason:** With  `force_binary_collation = true` option we execute following script every time on rails boot which is trying to update database which is not yet available. 

```
ActiveRecord::Migration.execute("ALTER TABLE tags MODIFY name varchar(255) CHARACTER SET utf8 COLLATE utf8_bin;")
```

This script should be executed only once not every time when rails is booted. User must set collation by re-running migration generator or run this rake task:

`rake acts_as_taggable_on_engine:tag_names:collate_bin`