### PR TITLE
case sensitivity fix for tagged_with #965

### DIFF
--- a/lib/acts_as_taggable_on/taggable/tagged_with_query/query_base.rb
+++ b/lib/acts_as_taggable_on/taggable/tagged_with_query/query_base.rb
@@ -29,9 +29,9 @@ module ActsAsTaggableOn::Taggable::TaggedWithQuery
       matches_attribute = matches_attribute.lower unless ActsAsTaggableOn.strict_case_match
 
       if options[:wild].present?
-        matches_attribute.matches("%#{escaped_tag(tag)}%", "!")
+        matches_attribute.matches("%#{escaped_tag(tag)}%", "!", ActsAsTaggableOn.strict_case_match)
       else
-        matches_attribute.matches(escaped_tag(tag), "!")
+        matches_attribute.matches(escaped_tag(tag), "!", ActsAsTaggableOn.strict_case_match)
       end
     end
 
@@ -40,9 +40,9 @@ module ActsAsTaggableOn::Taggable::TaggedWithQuery
       matches_attribute = matches_attribute.lower unless ActsAsTaggableOn.strict_case_match
 
       if options[:wild].present?
-        matches_attribute.matches_any(tag_list.map{|tag| "%#{escaped_tag(tag)}%"}, "!")
+        matches_attribute.matches_any(tag_list.map{|tag| "%#{escaped_tag(tag)}%"}, "!", ActsAsTaggableOn.strict_case_match)
       else
-        matches_attribute.matches_any(tag_list.map{|tag| "#{escaped_tag(tag)}"}, "!")
+        matches_attribute.matches_any(tag_list.map{|tag| "#{escaped_tag(tag)}"}, "!", ActsAsTaggableOn.strict_case_match)
       end
     end
 


### PR DESCRIPTION
Just a new PR for the work @endorfin did, i've cherry-picked it on top of the latest master.

It looks like @endorfin didn't see the request by @seuros to rebase the PR https://github.com/mbleigh/acts-as-taggable-on/pull/966 back in October 2019.

I'm currently using a forked version with their fix, and would hopefully like to get this into master.

---

Original PR: https://github.com/mbleigh/acts-as-taggable-on/pull/966
Original Issue: https://github.com/mbleigh/acts-as-taggable-on/issues/965

Original PR comment:
> arel matches and matches_any has a third parameter for case sensitivity, that was not set and always false. So ActsAsTaggableOn.strict_case_match didn't work with PostgreSQL