### PR TITLE
Added option +taggable_model_type+ to +tagged_with+ scope

### DIFF
--- a/lib/acts_as_taggable_on/taggable/tagged_with_query/all_tags_query.rb
+++ b/lib/acts_as_taggable_on/taggable/tagged_with_query/all_tags_query.rb
@@ -33,7 +33,7 @@ module ActsAsTaggableOn::Taggable::TaggedWithQuery
 
     def on_conditions(tag, tagging_alias)
       on_condition = tagging_alias[:taggable_id].eq(taggable_arel_table[taggable_model.primary_key])
-        .and(tagging_alias[:taggable_type].eq(taggable_model.base_class.name))
+        .and(tagging_alias[:taggable_type].eq(taggable_model_type))
         .and(
           tagging_alias[:tag_id].in(
             tag_arel_table.project(tag_arel_table[:id]).where(tag_match_type(tag))
@@ -62,7 +62,7 @@ module ActsAsTaggableOn::Taggable::TaggedWithQuery
 
     def match_all_on_conditions
       on_condition = tagging_arel_table[:taggable_id].eq(taggable_arel_table[taggable_model.primary_key])
-                      .and(tagging_arel_table[:taggable_type].eq(taggable_model.base_class.name))
+                      .and(tagging_arel_table[:taggable_type].eq(taggable_model_type))
 
       if options[:start_at].present?
         on_condition = on_condition.and(tagging_arel_table[:created_at].gteq(options[:start_at]))
@@ -104,7 +104,7 @@ module ActsAsTaggableOn::Taggable::TaggedWithQuery
     end
 
     def tagging_alias(tag)
-      alias_base_name = taggable_model.base_class.name.downcase
+      alias_base_name = taggable_model_type.downcase
       adjust_taggings_alias("#{alias_base_name[0..11]}_taggings_#{ActsAsTaggableOn::Utils.sha_prefix(tag)}")
     end
   end

--- a/lib/acts_as_taggable_on/taggable/tagged_with_query/any_tags_query.rb
+++ b/lib/acts_as_taggable_on/taggable/tagged_with_query/any_tags_query.rb
@@ -19,7 +19,7 @@ module ActsAsTaggableOn::Taggable::TaggedWithQuery
 
     def at_least_one_tag
       exists_contition = tagging_arel_table[:taggable_id].eq(taggable_arel_table[taggable_model.primary_key])
-                          .and(tagging_arel_table[:taggable_type].eq(taggable_model.base_class.name))
+                          .and(tagging_arel_table[:taggable_type].eq(taggable_model_type))
                           .and(
                             tagging_arel_table[:tag_id].in(
                               tag_arel_table.project(tag_arel_table[:id]).where(tags_match_type)
@@ -57,7 +57,7 @@ module ActsAsTaggableOn::Taggable::TaggedWithQuery
     end
 
     def alias_name(tag_list)
-      alias_base_name = taggable_model.base_class.name.downcase
+      alias_base_name = taggable_model_type.downcase
       taggings_context = options[:on] ? "_#{options[:on]}" : ''
 
       taggings_alias = adjust_taggings_alias(

--- a/lib/acts_as_taggable_on/taggable/tagged_with_query/exclude_tags_query.rb
+++ b/lib/acts_as_taggable_on/taggable/tagged_with_query/exclude_tags_query.rb
@@ -16,7 +16,7 @@ module ActsAsTaggableOn::Taggable::TaggedWithQuery
               .join(tag_arel_table)
               .on(
                   tagging_arel_table[:tag_id].eq(tag_arel_table[:id])
-                  .and(tagging_arel_table[:taggable_type].eq(taggable_model.base_class.name))
+                  .and(tagging_arel_table[:taggable_type].eq(taggable_model_type))
                   .and(tags_match_type)
                 )
           )
@@ -36,7 +36,7 @@ module ActsAsTaggableOn::Taggable::TaggedWithQuery
             tagging_arel_table[:tagger_id].eq(owner.id)
             .and(tagging_arel_table[:tagger_type].eq(owner.class.base_class.to_s))
             .and(tagging_arel_table[:taggable_id].eq(taggable_arel_table[taggable_model.primary_key]))
-            .and(tagging_arel_table[:taggable_type].eq(taggable_model.base_class.name))
+            .and(tagging_arel_table[:taggable_type].eq(taggable_model_type))
           )
 
       if options[:match_all].present?
@@ -52,7 +52,7 @@ module ActsAsTaggableOn::Taggable::TaggedWithQuery
 
     def match_all_on_conditions
       on_condition = tagging_arel_table[:taggable_id].eq(taggable_arel_table[taggable_model.primary_key])
-        .and(tagging_arel_table[:taggable_type].eq(taggable_model.base_class.name))
+        .and(tagging_arel_table[:taggable_type].eq(taggable_model_type))
 
       if options[:start_at].present?
         on_condition = on_condition.and(tagging_arel_table[:created_at].gteq(options[:start_at]))

--- a/lib/acts_as_taggable_on/taggable/tagged_with_query/query_base.rb
+++ b/lib/acts_as_taggable_on/taggable/tagged_with_query/query_base.rb
@@ -6,11 +6,12 @@ module ActsAsTaggableOn::Taggable::TaggedWithQuery
       @tagging_model  = tagging_model
       @tag_list       = tag_list
       @options        = options
+      @taggable_model_type  = options[:taggable_model_type] || taggable_model.base_class.name
     end
 
     private
 
-    attr_reader :taggable_model, :tag_model, :tagging_model, :tag_list, :options
+    attr_reader :taggable_model, :tag_model, :tagging_model, :tag_list, :options, :taggable_model_type
 
     def taggable_arel_table
       @taggable_arel_table ||= taggable_model.arel_table


### PR DESCRIPTION
### Context
When searching for multiple tags on different contexts on a model which is actually a **table view**, `tagged_with` will be translated based on taggable model.

On my particular case, this won't work as expected. The tags were created on the original model, not on the "table view" (this view is used for several calculations). I can't duplicate the tags on this table view as there will be a duplication of data.

### Issue

`ActsAsTaggableOn` will translate the query based on `taggable_model.base_class.name` which is the name of the _table view_, but not the table which actually is being referenced by that table view.

### Solution

I propose adding an optional parameter `taggable_model_type` to `tagged_with` method:

    ProviderView.tagged_with(tags_list, on: :context, taggable_model_type: 'Provider')

By allowing to specify the `taggable_model_type`, the query will search tags on the correct table (and not on the view), and make the calculations on the table view as expected.