### PR TITLE
Add support for Ruby 2.7 and it's kwargs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ services:
   - postgresql
 
 rvm:
+  - 2.7.0
   - 2.6.5
   - 2.5.5
   - 2.4.6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ Each change should fall into categories that would affect whether the release is
 
 As such, _Breaking Changes_ are major. _Features_ would map to either major or minor. _Fixes_, _Performance_, and _Misc_ are either minor or patch, the difference being kind of fuzzy for the purposes of history. Adding _Documentation_ (including tests) would be patch level.
 
+### [Master / Unreleased](https://github.com/mbleigh/acts-as-taggable-on/compare/v6.5.0...master)
+
+* Fixes
+  * [@nbulaj Add support for Ruby 2.7 and it's kwargs](https://github.com/mbleigh/acts-as-taggable-on/pull/910)  
+
 ### [6.5.0 / 2019-11-07](https://github.com/mbleigh/acts-as-taggable-on/compare/v6.0.0...v6.5.0)
 
 * Features

--- a/lib/acts_as_taggable_on/tagger.rb
+++ b/lib/acts_as_taggable_on/tagger.rb
@@ -18,7 +18,7 @@ module ActsAsTaggableOn
           owned_taggings_scope = opts.delete(:scope)
 
           has_many :owned_taggings, owned_taggings_scope,
-                   opts.merge(
+                   **opts.merge(
                      as: :tagger,
                      class_name: '::ActsAsTaggableOn::Tagging',
                      dependent: :destroy

--- a/lib/acts_as_taggable_on/tagging.rb
+++ b/lib/acts_as_taggable_on/tagging.rb
@@ -6,7 +6,7 @@ module ActsAsTaggableOn
     belongs_to :tag, class_name: '::ActsAsTaggableOn::Tag', counter_cache: ActsAsTaggableOn.tags_counter
     belongs_to :taggable, polymorphic: true
 
-    belongs_to :tagger, { polymorphic: true, optional: true }
+    belongs_to :tagger, polymorphic: true, optional: true
 
     scope :owned_by, ->(owner) { where(tagger: owner) }
     scope :not_owned, -> { where(tagger_id: nil, tagger_type: nil) }

--- a/spec/acts_as_taggable_on/taggable_spec.rb
+++ b/spec/acts_as_taggable_on/taggable_spec.rb
@@ -477,7 +477,7 @@ describe 'Taggable' do
 
       expect(TaggableModel.tagged_with(%w(bob tricia), wild: true, any: true).to_a.sort_by { |o| o.id }).to eq([bob, frank, steve])
       expect(TaggableModel.tagged_with(%w(bob tricia), wild: true, exclude: true).to_a).to eq([jim])
-      expect(TaggableModel.tagged_with('ji', wild: true, any: true).to_a =~ [frank, jim])
+      expect(TaggableModel.tagged_with('ji', wild: true, any: true).to_a).to match_array([frank, jim])
     end
   end
 


### PR DESCRIPTION
Ruby 2.7.0 was released December 25, 2019, and has some noisy [deprecation messages about keyword arguments](https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/).

`acts-as-taggable-on` calls multiple methods from ActiveRecord that have kwargs as the last argument and produce warnings to stdout.

So, what's done here:

* Add Ruby 2.7 to Travis matrix
* Get rid of kwargs deprecation messages from the gem