### PR TITLE
Support tenants for taggings

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ Review the generated migrations then migrate :
 rake db:migrate
 ```
 
+If you do not wish or need to support multi-tenancy, the migration for `add_tenant_to_taggings` is optional and can be discarded safely.
+
 #### For MySql users
 You can circumvent at any time the problem of special characters [issue 623](https://github.com/mbleigh/acts-as-taggable-on/issues/623) by setting in an initializer file:
 
@@ -352,6 +354,27 @@ Photo.tagged_with("paris", :on => :locations, :owned_by => @some_user)
 @some_photo.owner_tags_on(@some_user, :locations) # => [#<ActsAsTaggableOn::Tag id: 1, name: "paris">...]
 @some_photo.owner_tags_on(nil, :locations) # => Ownerships equivalent to saying @some_photo.locations
 @some_user.tag(@some_photo, :with => "paris, normandy", :on => :locations, :skip_save => true) #won't save @some_photo object
+```
+
+### Tag Tenancy
+
+Tags support multi-tenancy. This is useful for applications where a Tag belongs to a scoped set of models:
+
+```ruby
+class Account < ActiveRecord::Base
+  has_many :photos
+end
+
+class User < ActiveRecord::Base
+  belongs_to :account
+  acts_as_taggable_on :tags
+  acts_as_taggable_tenant :account_id
+end
+
+@user1.tag_list = ["foo", "bar"] # these taggings will automatically have the tenant saved
+@user2.tag_list = ["bar", "baz"] 
+
+ActsAsTaggableOn::Tag.for_tenant(@user1.account.id) # returns Tag models for "foo" and "bar", but not "baz"
 ```
 
 #### Working with Owned Tags

--- a/README.md
+++ b/README.md
@@ -356,27 +356,6 @@ Photo.tagged_with("paris", :on => :locations, :owned_by => @some_user)
 @some_user.tag(@some_photo, :with => "paris, normandy", :on => :locations, :skip_save => true) #won't save @some_photo object
 ```
 
-### Tag Tenancy
-
-Tags support multi-tenancy. This is useful for applications where a Tag belongs to a scoped set of models:
-
-```ruby
-class Account < ActiveRecord::Base
-  has_many :photos
-end
-
-class User < ActiveRecord::Base
-  belongs_to :account
-  acts_as_taggable_on :tags
-  acts_as_taggable_tenant :account_id
-end
-
-@user1.tag_list = ["foo", "bar"] # these taggings will automatically have the tenant saved
-@user2.tag_list = ["bar", "baz"] 
-
-ActsAsTaggableOn::Tag.for_tenant(@user1.account.id) # returns Tag models for "foo" and "bar", but not "baz"
-```
-
 #### Working with Owned Tags
 Note that `tag_list` only returns tags whose taggings do not have an owner. Continuing from the above example:
 ```ruby
@@ -411,6 +390,27 @@ def remove_owned_tag
     @tag_owner.tag(@some_item, :with => stringify(owned_tag_list), :on => :tags)
     @some_item.save
 end
+```
+
+### Tag Tenancy
+
+Tags support multi-tenancy. This is useful for applications where a Tag belongs to a scoped set of models:
+
+```ruby
+class Account < ActiveRecord::Base
+  has_many :photos
+end
+
+class User < ActiveRecord::Base
+  belongs_to :account
+  acts_as_taggable_on :tags
+  acts_as_taggable_tenant :account_id
+end
+
+@user1.tag_list = ["foo", "bar"] # these taggings will automatically have the tenant saved
+@user2.tag_list = ["bar", "baz"]
+
+ActsAsTaggableOn::Tag.for_tenant(@user1.account.id) # returns Tag models for "foo" and "bar", but not "baz"
 ```
 
 ### Dirty objects

--- a/db/migrate/7_add_tenant_to_taggings.rb
+++ b/db/migrate/7_add_tenant_to_taggings.rb
@@ -1,0 +1,16 @@
+if ActiveRecord.gem_version >= Gem::Version.new('5.0')
+  class AddTenantToTaggings < ActiveRecord::Migration[4.2]; end
+else
+  class AddTenantToTaggings < ActiveRecord::Migration; end
+end
+AddTenantToTaggings.class_eval do
+  def self.up
+    add_column :taggings, :tenant, :string, limit: 128
+    add_index :taggings, :tenant unless index_exists? :taggings, :tenant
+  end
+
+  def self.down
+    remove_column :taggings, :tenant
+    remove_index :taggings, :tenant
+  end
+end

--- a/lib/acts_as_taggable_on/tag.rb
+++ b/lib/acts_as_taggable_on/tag.rb
@@ -57,8 +57,8 @@ module ActsAsTaggableOn
 
     def self.for_tenant(tenant)
       joins(:taggings).
-        where("taggings.tenant = ?", tenant).
-        select("DISTINCT tags.*")
+        where("#{ActsAsTaggableOn.taggings_table}.tenant = ?", tenant.to_s).
+        select("DISTINCT #{ActsAsTaggableOn.tags_table}.*")
     end
 
     ### CLASS METHODS:

--- a/lib/acts_as_taggable_on/tag.rb
+++ b/lib/acts_as_taggable_on/tag.rb
@@ -55,6 +55,12 @@ module ActsAsTaggableOn
         select("DISTINCT #{ActsAsTaggableOn.tags_table}.*")
     end
 
+    def self.for_tenant(tenant)
+      joins(:taggings).
+        where("taggings.tenant = ?", tenant).
+        select("DISTINCT tags.*")
+    end
+
     ### CLASS METHODS:
 
     def self.find_or_create_with_like_by_name(name)

--- a/lib/acts_as_taggable_on/taggable.rb
+++ b/lib/acts_as_taggable_on/taggable.rb
@@ -54,6 +54,23 @@ module ActsAsTaggableOn
       taggable_on(true, tag_types)
     end
 
+    def acts_as_taggable_tenant(tenant)
+      if taggable?
+        self.tenant_column = tenant
+      else
+        class_attribute :tenant_column
+        self.tenant_column = tenant
+      end
+
+      # each of these add context-specific methods and must be
+      # called on each call of taggable_on
+      include Core
+      include Collection
+      include Cache
+      include Ownership
+      include Related
+    end
+
     private
 
       # Make a model taggable on specified contexts
@@ -78,6 +95,7 @@ module ActsAsTaggableOn
         self.tag_types = tag_types
         class_attribute :preserve_tag_order
         self.preserve_tag_order = preserve_tag_order
+        class_attribute :tenant_column
 
         class_eval do
           has_many :taggings, as: :taggable, dependent: :destroy, class_name: '::ActsAsTaggableOn::Tagging'

--- a/lib/acts_as_taggable_on/taggable/core.rb
+++ b/lib/acts_as_taggable_on/taggable/core.rb
@@ -278,8 +278,12 @@ module ActsAsTaggableOn::Taggable
 
         # Create new taggings:
         new_tags.each do |tag|
-          taggings.create!(tag_id: tag.id, context: context.to_s, taggable: self, tenant: tenant)
-        end
+          if tenant
+            taggings.create!(tag_id: tag.id, context: context.to_s, taggable: self, tenant: tenant)
+          else
+            taggings.create!(tag_id: tag.id, context: context.to_s, taggable: self)
+          end
+         end
       end
 
       true

--- a/lib/acts_as_taggable_on/taggable/core.rb
+++ b/lib/acts_as_taggable_on/taggable/core.rb
@@ -214,6 +214,12 @@ module ActsAsTaggableOn::Taggable
       self.class.tag_types.map(&:to_s) + custom_contexts
     end
 
+    def tenant
+      if self.class.tenant_column
+        read_attribute(self.class.tenant_column)
+      end
+    end
+
     def reload(*args)
       self.class.tag_types.each do |context|
         instance_variable_set("@#{context.to_s.singularize}_list", nil)
@@ -272,7 +278,7 @@ module ActsAsTaggableOn::Taggable
 
         # Create new taggings:
         new_tags.each do |tag|
-          taggings.create!(tag_id: tag.id, context: context.to_s, taggable: self)
+          taggings.create!(tag_id: tag.id, context: context.to_s, taggable: self, tenant: tenant)
         end
       end
 

--- a/lib/acts_as_taggable_on/taggable/core.rb
+++ b/lib/acts_as_taggable_on/taggable/core.rb
@@ -283,7 +283,7 @@ module ActsAsTaggableOn::Taggable
           else
             taggings.create!(tag_id: tag.id, context: context.to_s, taggable: self)
           end
-         end
+        end
       end
 
       true

--- a/lib/acts_as_taggable_on/tagging.rb
+++ b/lib/acts_as_taggable_on/tagging.rb
@@ -14,6 +14,8 @@ module ActsAsTaggableOn
     scope :by_contexts, ->(contexts) { where(context: (contexts || DEFAULT_CONTEXT)) }
     scope :by_context, ->(context = DEFAULT_CONTEXT) { by_contexts(context.to_s) }
 
+    scope :by_tenant, ->(tenant) { where(tenant: tenant) }
+
     validates_presence_of :context
     validates_presence_of :tag_id
 

--- a/spec/acts_as_taggable_on/tag_spec.rb
+++ b/spec/acts_as_taggable_on/tag_spec.rb
@@ -14,7 +14,7 @@ end
 describe ActsAsTaggableOn::Tag do
   before(:each) do
     @tag = ActsAsTaggableOn::Tag.new
-    @user = TaggableModel.create(name: 'Pablo')
+    @user = TaggableModel.create(name: 'Pablo', tenant_id: 100)
   end
 
 
@@ -67,6 +67,21 @@ describe ActsAsTaggableOn::Tag do
 
     it 'should not return tags that have been used in other contexts' do
       expect(ActsAsTaggableOn::Tag.for_context('needs').pluck(:name)).to_not include('ruby')
+    end
+  end
+
+  describe 'for tenant' do
+    before(:each) do
+      @user.skill_list.add('ruby')
+      @user.save
+    end
+
+    it 'should return tags for the tenant' do
+      expect(ActsAsTaggableOn::Tag.for_tenant('100').pluck(:name)).to include('ruby')
+    end
+
+    it 'should not return tags for other tenants' do
+      expect(ActsAsTaggableOn::Tag.for_tenant('200').pluck(:name)).to_not include('ruby')
     end
   end
 

--- a/spec/acts_as_taggable_on/taggable_spec.rb
+++ b/spec/acts_as_taggable_on/taggable_spec.rb
@@ -109,6 +109,10 @@ describe 'Taggable' do
     expect(@taggable.tag_types).to eq(TaggableModel.tag_types)
   end
 
+  it 'should have tenant column' do
+    expect(TaggableModel.tenant_column).to eq(:tenant_id)
+  end
+
   it 'should have tag_counts_on' do
     expect(TaggableModel.tag_counts_on(:tags)).to be_empty
 
@@ -676,11 +680,11 @@ describe 'Taggable' do
     end
 
     it 'should return all column names joined for TaggableModel GROUP clause' do
-      expect(@taggable.grouped_column_names_for(TaggableModel)).to eq('taggable_models.id, taggable_models.name, taggable_models.type')
+      expect(@taggable.grouped_column_names_for(TaggableModel)).to eq('taggable_models.id, taggable_models.name, taggable_models.type, taggable_models.tenant_id')
     end
 
     it 'should return all column names joined for NonStandardIdTaggableModel GROUP clause' do
-      expect(@taggable.grouped_column_names_for(TaggableModel)).to eq("taggable_models.#{TaggableModel.primary_key}, taggable_models.name, taggable_models.type")
+      expect(@taggable.grouped_column_names_for(TaggableModel)).to eq("taggable_models.#{TaggableModel.primary_key}, taggable_models.name, taggable_models.type, taggable_models.tenant_id")
     end
   end
 

--- a/spec/acts_as_taggable_on/tagging_spec.rb
+++ b/spec/acts_as_taggable_on/tagging_spec.rb
@@ -61,12 +61,14 @@ describe ActsAsTaggableOn::Tagging do
       @tagging.tag = ActsAsTaggableOn::Tag.create(name: "Physics")
       @tagging.tagger = @tagger
       @tagging.context = 'Science'
+      @tagging.tenant = 'account1'
       @tagging.save
 
       @tagging_2.taggable = TaggableModel.create(name: "Satellites")
       @tagging_2.tag = ActsAsTaggableOn::Tag.create(name: "Technology")
       @tagging_2.tagger = @tagger_2
       @tagging_2.context = 'Science'
+      @tagging_2.tenant = 'account1'
       @tagging_2.save
 
       @tagging_3.taggable = TaggableModel.create(name: "Satellites")
@@ -95,6 +97,14 @@ describe ActsAsTaggableOn::Tagging do
         expect(ActsAsTaggableOn::Tagging.by_contexts(['Science', 'Astronomy']).second).to eq(@tagging_2);
         expect(ActsAsTaggableOn::Tagging.by_contexts(['Science', 'Astronomy']).third).to eq(@tagging_3);
         expect(ActsAsTaggableOn::Tagging.by_contexts(['Science', 'Astronomy']).length).to eq(3);
+      end
+    end
+
+    describe '.by_tenant' do
+      it "should find taggings by tenant" do
+        expect(ActsAsTaggableOn::Tagging.by_tenant('account1').length).to eq(2);
+        expect(ActsAsTaggableOn::Tagging.by_tenant('account1').first).to eq(@tagging);
+        expect(ActsAsTaggableOn::Tagging.by_tenant('account1').second).to eq(@tagging_2);
       end
     end
 

--- a/spec/internal/app/models/taggable_model.rb
+++ b/spec/internal/app/models/taggable_model.rb
@@ -3,6 +3,8 @@ class TaggableModel < ActiveRecord::Base
   acts_as_taggable_on :languages
   acts_as_taggable_on :skills
   acts_as_taggable_on :needs, :offerings
+  acts_as_taggable_tenant :tenant_id
+
   has_many :untaggable_models
 
   attr_reader :tag_list_submethod_called

--- a/spec/internal/db/schema.rb
+++ b/spec/internal/db/schema.rb
@@ -21,6 +21,8 @@ ActiveRecord::Schema.define version: 0 do
     # length for MyISAM table type: http://bit.ly/vgW2Ql
     t.string :context, limit: 128
 
+    t.string :tenant , limit: 128
+
     t.datetime :created_at
   end
   add_index ActsAsTaggableOn.taggings_table,
@@ -34,6 +36,7 @@ ActiveRecord::Schema.define version: 0 do
   create_table :taggable_models, force: true do |t|
     t.column :name, :string
     t.column :type, :string
+    t.column :tenant_id, :integer
   end
 
   create_table :columns_override_models, force: true do |t|


### PR DESCRIPTION
@seuros Let me know if I should be tagging (pun intended) other contributors to get attention to this PR.

I'm opening up this PR to add `tenant` capabilities to `acts-as-taggable-on`. Specifically this would be helpful for multi-tenant applications that will want to use a `tenant` column to track ownership.

I know there's an `owner` concept already in this gem, but that doesn't handle the case where you want to track the user who tagged the object as well as the tenant_id for partitioning purposes.

We use this gem (via a fork right now) across millions of rows and this helps keep performance sane. However, we'd love to get this change merged back into the root repo for future compatibility. It's also being introduced here in a way that will not impact existing usage syntax.

Would love to get your thoughts on the acceptability on this idea. 