### PR TITLE
Add case sensitivity on Tag name for Rails 6

### DIFF
--- a/lib/acts_as_taggable_on/tag.rb
+++ b/lib/acts_as_taggable_on/tag.rb
@@ -10,7 +10,7 @@ module ActsAsTaggableOn
     ### VALIDATIONS:
 
     validates_presence_of :name
-    validates_uniqueness_of :name, if: :validates_name_uniqueness?
+    validates_uniqueness_of :name, if: :validates_name_uniqueness?, case_sensitive: true
     validates_length_of :name, maximum: 255
 
     # monkey patch this method if don't need name uniqueness validation


### PR DESCRIPTION
I'm seeing lots of deprecations warnings in Rails 6.
This fixes the issue.