### PR TITLE
Use a custom validation method to validate the uniqueness of name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Each change should fall into categories that would affect whether the release is
 
 As such, _Breaking Changes_ are major. _Features_ would map to either major or minor. _Fixes_, _Performance_, and _Misc_ are either minor or patch, the difference being kind of fuzzy for the purposes of history. Adding _Documentation_ (including tests) would be patch level.
 
+### [Master / Unreleased](https://github.com/mbleigh/acts-as-taggable-on/compare/v9.0.1...master)
+* Fixes
+  * [@FunnyHector Fix the uniqueness validator deprecation warning on Rails 6](https://github.com/mbleigh/acts-as-taggable-on/pull/1009)
+
 ### [v9.0.1) / 2022-01-07](https://github.com/mbleigh/acts-as-taggable-on/compare/v8.1.0...v9.0.0)
 * Fixes
   * Fix migration that generate default index

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,6 @@ As such, _Breaking Changes_ are major. _Features_ would map to either major or m
 * Features
   * [@glampr Add support for prefix and suffix searches alongside previously supported containment (wildcard) searches](https://github.com/mbleigh/acts-as-taggable-on/pull/1082)
   * [@donquxiote Add support for horizontally sharded databases](https://github.com/mbleigh/acts-as-taggable-on/pull/1079)
-* Fixes
-  * [@FunnyHector Fix the uniqueness validator deprecation warning on Rails 6](https://github.com/mbleigh/acts-as-taggable-on/pull/1009)
 
 ### [v9.0.1) / 2022-01-07](https://github.com/mbleigh/acts-as-taggable-on/compare/v9.0.0..v9.0.1)
 * Fixes

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,0 +1,8 @@
+en:
+  activerecord:
+    errors:
+      models:
+        acts_as_taggable_on/tag:
+          attributes:
+            name:
+              not_unique: has already been taken (using %{type_of_comparison} comparison)

--- a/db/migrate/5_change_collation_for_tag_names.rb
+++ b/db/migrate/5_change_collation_for_tag_names.rb
@@ -9,4 +9,10 @@ class ChangeCollationForTagNames < ActiveRecord::Migration[6.0]
       execute("ALTER TABLE #{ActsAsTaggableOn.tags_table} MODIFY name varchar(255) CHARACTER SET utf8 COLLATE utf8_bin;")
     end
   end
+
+  def down
+    if ActsAsTaggableOn::Utils.using_mysql?
+      execute("ALTER TABLE #{ActsAsTaggableOn.tags_table} MODIFY name varchar(255) CHARACTER SET utf8 COLLATE utf8_unicode_ci;")
+    end
+  end
 end

--- a/lib/acts_as_taggable_on/tag.rb
+++ b/lib/acts_as_taggable_on/tag.rb
@@ -11,8 +11,9 @@ module ActsAsTaggableOn
     ### VALIDATIONS:
 
     validates_presence_of :name
-    validates_uniqueness_of :name, if: :validates_name_uniqueness?, case_sensitive: true
     validates_length_of :name, maximum: 255
+
+    validate :name_is_unique
 
     # monkey patch this method if don't need name uniqueness validation
     def validates_name_uniqueness?
@@ -108,6 +109,17 @@ module ActsAsTaggableOn
 
     def count
       read_attribute(:count).to_i
+    end
+
+    private
+
+    def name_is_unique
+      return unless self.class.named(name).exists?
+
+      type_of_comparison = ActsAsTaggableOn.strict_case_match ? 'case-sensitive' : 'case-insensitive'
+      error_message = "has already been taken (using #{type_of_comparison} comparison)"
+
+      errors.add(:name, error_message)
     end
 
     class << self

--- a/lib/acts_as_taggable_on/tag.rb
+++ b/lib/acts_as_taggable_on/tag.rb
@@ -117,9 +117,7 @@ module ActsAsTaggableOn
       return unless self.class.named(name).exists?
 
       type_of_comparison = ActsAsTaggableOn.strict_case_match ? 'case-sensitive' : 'case-insensitive'
-      error_message = "has already been taken (using #{type_of_comparison} comparison)"
-
-      errors.add(:name, error_message)
+      errors.add(:name, :not_unique, type_of_comparison: type_of_comparison)
     end
 
     class << self

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,7 +7,10 @@ $LOAD_PATH.unshift(File.expand_path('../../lib', __FILE__))
 require 'logger'
 
 require File.expand_path('../../lib/acts-as-taggable-on', __FILE__)
+
+I18n.load_path << File.expand_path('../../config/locales/en.yml', __FILE__)
 I18n.enforce_available_locales = true
+
 require 'rails'
 require 'rspec/its'
 require 'barrier'


### PR DESCRIPTION
Use a custom validation method to validate the uniqueness of name

The intention of this change is to address the the following deprecation seen on Rails 6:

    DEPRECATION WARNING: Uniqueness validator will no longer enforce
    case sensitive comparison in Rails 6.1. To continue case sensitive
    comparison on the :name attribute in ActsAsTaggableOn::Tag model,
    pass `case_sensitive: true` option explicitly to the uniqueness
    validator.

Since there is the complexity of the config `ActsAsTaggableOn.strict_case_match`, we can't just explicitly set case_sensitive option as suggested in the deprecation warning.

The tests are quite blargh to deal with since the test database has the collation set to case-insensitive and has an uniqueness index, which is not realistic. To deal with the tests, I used a similar approach as in cb8d6e65cbb65a02a05f3deb28c12d5439d745af. In cases where case sensitivity matters, we alter the collation on `name` column, run the test, then alter the collation back.

This PR tries to solve the same problem mentioned in #1005, but since the author of #1005 hasn't responded, I'm trying my luck here.

This change has also adopted [@graaff's suggestion](https://github.com/mbleigh/acts-as-taggable-on/pull/1005#discussion_r511326975)