### PR TITLE
Use none? instead of count.zero?

### DIFF
--- a/lib/acts_as_taggable_on/tagging.rb
+++ b/lib/acts_as_taggable_on/tagging.rb
@@ -28,7 +28,7 @@ module ActsAsTaggableOn
         if ActsAsTaggableOn.tags_counter
           tag.destroy if tag.reload.taggings_count.zero?
         else
-          tag.destroy if tag.reload.taggings.count.zero?
+          tag.destroy if tag.reload.taggings.none?
         end
       end
     end

--- a/spec/acts_as_taggable_on/tagging_spec.rb
+++ b/spec/acts_as_taggable_on/tagging_spec.rb
@@ -49,6 +49,22 @@ describe ActsAsTaggableOn::Tagging do
     ActsAsTaggableOn.remove_unused_tags = previous_setting
   end
 
+  it 'should destroy unused tags after tagging destroyed when not using tags_counter' do
+    remove_unused_tags_previous_setting = ActsAsTaggableOn.remove_unused_tags
+    tags_counter_previous_setting = ActsAsTaggableOn.tags_counter
+    ActsAsTaggableOn.remove_unused_tags = true
+    ActsAsTaggableOn.tags_counter = false
+
+    ActsAsTaggableOn::Tag.destroy_all
+    @taggable = TaggableModel.create(name: 'Bob Jones')
+    @taggable.update_attribute :tag_list, 'aaa,bbb,ccc'
+    @taggable.update_attribute :tag_list, ''
+    expect(ActsAsTaggableOn::Tag.count).to eql(0)
+
+    ActsAsTaggableOn.remove_unused_tags = remove_unused_tags_previous_setting
+    ActsAsTaggableOn.tags_counter = tags_counter_previous_setting
+  end
+
   describe 'context scopes' do
     before do
       @tagging_2 = ActsAsTaggableOn::Tagging.new


### PR DESCRIPTION
We have run in to a performance issue when removing unused tags and not using the `tags_counter`

`taggings.count.zero?` executes the following sql
```sql
`SELECT COUNT(*) FROM taggings WHERE taggings.tag_id = ?`
```

This can be very slow on large tables 

by using `taggings.none?` it instead executes:
```sql
`SELECT 1 AS one FROM taggings WHERE taggings.tag_id = 304185392 LIMIT 1`
```

which can always use the index and is much faster.