### PR TITLE
Added strict_default_collation_match as a config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -488,6 +488,12 @@ If you would like to have an exact match covering special characters with MySql:
 ActsAsTaggableOn.force_binary_collation = true
 ```
 
+If you would like to not use `LOWER` for comparison queries and do not need to use `strict_case_match` or `force_binary_collation`. 
+
+```ruby
+ActsAsTaggableOn.strict_default_collation_match = true
+```
+
 If you would like to specify table names:
 
 ```ruby

--- a/lib/acts-as-taggable-on.rb
+++ b/lib/acts-as-taggable-on.rb
@@ -66,7 +66,7 @@ module ActsAsTaggableOn
                   :remove_unused_tags, :default_parser,
                   :tags_counter, :tags_table,
                   :taggings_table
-    attr_reader :delimiter, :strict_case_match
+    attr_reader :delimiter, :strict_case_match, :strict_default_collation_match
 
     def initialize
       @delimiter = ','
@@ -79,10 +79,15 @@ module ActsAsTaggableOn
       @force_binary_collation = false
       @tags_table = :tags
       @taggings_table = :taggings
+      @strict_default_collation_match = false
     end
 
     def strict_case_match=(force_cs)
       @strict_case_match = force_cs unless @force_binary_collation
+    end
+
+    def strict_default_collation_match=(force_cs)
+      @strict_default_collation_match = force_cs unless @strict_case_match
     end
 
     def delimiter=(string)

--- a/lib/acts_as_taggable_on/tag.rb
+++ b/lib/acts_as_taggable_on/tag.rb
@@ -25,6 +25,8 @@ module ActsAsTaggableOn
     def self.named(name)
       if ActsAsTaggableOn.strict_case_match
         where(["name = #{binary}?", as_8bit_ascii(name)])
+      elsif ActsAsTaggableOn.strict_default_collation_match
+        where(["name = ?", as_8bit_ascii(name)])
       else
         where(['LOWER(name) = LOWER(?)', as_8bit_ascii(unicode_downcase(name))])
       end
@@ -58,7 +60,7 @@ module ActsAsTaggableOn
     ### CLASS METHODS:
 
     def self.find_or_create_with_like_by_name(name)
-      if ActsAsTaggableOn.strict_case_match
+      if ActsAsTaggableOn.strict_case_match || ActsAsTaggableOn.strict_default_collation_match
         self.find_or_create_all_with_like_by_name([name]).first
       else
         named_like(name).first || create(name: name)
@@ -108,7 +110,7 @@ module ActsAsTaggableOn
       private
 
       def comparable_name(str)
-        if ActsAsTaggableOn.strict_case_match
+        if ActsAsTaggableOn.strict_case_match || ActsAsTaggableOn.strict_default_collation_match
           str
         else
           unicode_downcase(str.to_s)
@@ -130,6 +132,8 @@ module ActsAsTaggableOn
       def sanitize_sql_for_named_any(tag)
         if ActsAsTaggableOn.strict_case_match
           sanitize_sql(["name = #{binary}?", as_8bit_ascii(tag)])
+        elsif ActsAsTaggableOn.strict_default_collation_match
+          sanitize_sql(["name = ?", as_8bit_ascii(tag)])
         else
           sanitize_sql(['LOWER(name) = LOWER(?)', as_8bit_ascii(unicode_downcase(tag))])
         end

--- a/lib/acts_as_taggable_on/taggable/tagged_with_query/query_base.rb
+++ b/lib/acts_as_taggable_on/taggable/tagged_with_query/query_base.rb
@@ -26,7 +26,7 @@ module ActsAsTaggableOn::Taggable::TaggedWithQuery
 
     def tag_match_type(tag)
       matches_attribute = tag_arel_table[:name]
-      matches_attribute = matches_attribute.lower unless ActsAsTaggableOn.strict_case_match
+      matches_attribute = matches_attribute.lower unless ActsAsTaggableOn.strict_case_match || ActsAsTaggableOn.strict_default_collation_match
 
       if options[:wild].present?
         matches_attribute.matches("%#{escaped_tag(tag)}%", "!", ActsAsTaggableOn.strict_case_match)
@@ -37,7 +37,7 @@ module ActsAsTaggableOn::Taggable::TaggedWithQuery
 
     def tags_match_type
       matches_attribute = tag_arel_table[:name]
-      matches_attribute = matches_attribute.lower unless ActsAsTaggableOn.strict_case_match
+      matches_attribute = matches_attribute.lower unless ActsAsTaggableOn.strict_case_match || ActsAsTaggableOn.strict_default_collation_match
 
       if options[:wild].present?
         matches_attribute.matches_any(tag_list.map{|tag| "%#{escaped_tag(tag)}%"}, "!", ActsAsTaggableOn.strict_case_match)
@@ -47,7 +47,7 @@ module ActsAsTaggableOn::Taggable::TaggedWithQuery
     end
 
     def escaped_tag(tag)
-      tag = tag.downcase unless ActsAsTaggableOn.strict_case_match
+      tag = tag.downcase unless ActsAsTaggableOn.strict_case_match || ActsAsTaggableOn.strict_default_collation_match
       ActsAsTaggableOn::Utils.escape_like(tag)
     end
 


### PR DESCRIPTION
If you don't need tags to be case-sensitive and want to use database indexing instead of using `LOWER`.