### PR TITLE
fix #1036 scope taggable#tenant method name to #taggable_tenant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ Each change should fall into categories that would affect whether the release is
 
 As such, _Breaking Changes_ are major. _Features_ would map to either major or minor. _Fixes_, _Performance_, and _Misc_ are either minor or patch, the difference being kind of fuzzy for the purposes of history. Adding _Documentation_ (including tests) would be patch level.
 
+### [v8.1.0) / 2021-06-17](https://github.com/mbleigh/acts-as-taggable-on/compare/v8.0.0...v8.1.0)
+* Fixes
+ * [@ngouy Fix rollbackable tenant migrations](https://github.com/mbleigh/acts-as-taggable-on/pull/1038)
+ * [@ngouy Fix gem conflict with already existing tenant model](https://github.com/mbleigh/acts-as-taggable-on/pull/1037)
+
 ### [v8.0.0) / 2021-06-07](https://github.com/mbleigh/acts-as-taggable-on/compare/v7.0.0...v8.0.0)
 * Features
   * [@lunaru Support tenants for taggings](https://github.com/mbleigh/acts-as-taggable-on/pull/1000)

--- a/Gemfile
+++ b/Gemfile
@@ -7,5 +7,6 @@ group :local_development do
   gem 'guard-rspec'
   gem 'appraisal'
   gem 'rake'
+  gem 'sqlite3'
   gem 'byebug', platforms: [:mri]
 end

--- a/lib/acts_as_taggable_on/taggable/core.rb
+++ b/lib/acts_as_taggable_on/taggable/core.rb
@@ -214,9 +214,9 @@ module ActsAsTaggableOn::Taggable
       self.class.tag_types.map(&:to_s) + custom_contexts
     end
 
-    def tenant
+    def taggable_tenant
       if self.class.tenant_column
-        read_attribute(self.class.tenant_column)
+        public_send(self.class.tenant_column)
       end
     end
 
@@ -278,8 +278,8 @@ module ActsAsTaggableOn::Taggable
 
         # Create new taggings:
         new_tags.each do |tag|
-          if tenant
-            taggings.create!(tag_id: tag.id, context: context.to_s, taggable: self, tenant: tenant)
+          if taggable_tenant
+            taggings.create!(tag_id: tag.id, context: context.to_s, taggable: self, tenant: taggable_tenant)
           else
             taggings.create!(tag_id: tag.id, context: context.to_s, taggable: self)
           end

--- a/lib/acts_as_taggable_on/version.rb
+++ b/lib/acts_as_taggable_on/version.rb
@@ -1,3 +1,3 @@
 module ActsAsTaggableOn
-  VERSION = '8.0.0'
+  VERSION = '8.1.0'
 end


### PR DESCRIPTION
If your taggable model already have a #tenant attribute/method/relationship, it would broke your code.

A small modification is required to scope this (non-documented and normally non directly used) method to the taggable lexical scope to fix the issue