### PR TITLE
fix non rollbackable tenant migration

### DIFF
--- a/db/migrate/7_add_tenant_to_taggings.rb
+++ b/db/migrate/7_add_tenant_to_taggings.rb
@@ -10,7 +10,7 @@ AddTenantToTaggings.class_eval do
   end
 
   def self.down
-    remove_column :taggings, :tenant
     remove_index :taggings, :tenant
+    remove_column :taggings, :tenant
   end
 end


### PR DESCRIPTION
If you remove a column, the indexes are by default also removed
Thus this migration causes following if we try to rollback
![image](https://user-images.githubusercontent.com/12391171/122462250-5e510c00-cf82-11eb-96c9-2171dff335d5.png)

2 possible solutions:
remove the `remove_index` or move it up

I chose the latter so up and down are symmetric, it's more esthetic and explicit.