### PR TITLE
Update README with the modern version number

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ was used.
 To use it, add it to your Gemfile:
 
 ```ruby
-gem 'acts-as-taggable-on', '~> 7.0'
+gem 'acts-as-taggable-on', '~> 8.0'
 ```
 
 and bundle:


### PR DESCRIPTION
Since the gem is at version 8.x, the docs should reflect that. :)