### PR TITLE
Add support for a list of taggable IDs in the tagging conditions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Each change should fall into categories that would affect whether the release is
 
 As such, _Breaking Changes_ are major. _Features_ would map to either major or minor. _Fixes_, _Performance_, and _Misc_ are either minor or patch, the difference being kind of fuzzy for the purposes of history. Adding _Documentation_ (including tests) would be patch level.
 
-### [v8.2.0) / 2021-10-19](https://github.com/mbleigh/acts-as-taggable-on/compare/v8.1.0...v8.2.0)
+### [v9.0.0) / 2021-10-19](https://github.com/mbleigh/acts-as-taggable-on/compare/v8.1.0...v9.0.0)
 * Features
  * [@moliver-hemasystems Add support for a list of taggable IDs in tagging conditions](https://github.com/mbleigh/acts-as-taggable-on/pull/1053)
 
@@ -29,8 +29,8 @@ As such, _Breaking Changes_ are major. _Features_ would map to either major or m
 * Features
   * [@kvokka Rails 6.1 support](https://github.com/mbleigh/acts-as-taggable-on/pull/1013)
 * Fixes
-  * [@nbulaj Add support for Ruby 2.7 and it's kwargs](https://github.com/mbleigh/acts-as-taggable-on/pull/910)  
-  * [@Andythurlow @endorfin case sensitivity fix for tagged_with](https://github.com/mbleigh/acts-as-taggable-on/pull/965)  
+  * [@nbulaj Add support for Ruby 2.7 and it's kwargs](https://github.com/mbleigh/acts-as-taggable-on/pull/910)
+  * [@Andythurlow @endorfin case sensitivity fix for tagged_with](https://github.com/mbleigh/acts-as-taggable-on/pull/965)
 
 ### [6.5.0 / 2019-11-07](https://github.com/mbleigh/acts-as-taggable-on/compare/v6.0.0...v6.5.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Each change should fall into categories that would affect whether the release is
 
 As such, _Breaking Changes_ are major. _Features_ would map to either major or minor. _Fixes_, _Performance_, and _Misc_ are either minor or patch, the difference being kind of fuzzy for the purposes of history. Adding _Documentation_ (including tests) would be patch level.
 
+### [v8.2.0) / 2021-10-19](https://github.com/mbleigh/acts-as-taggable-on/compare/v8.1.0...v8.2.0)
+* Features
+ * [@moliver-hemasystems Add support for a list of taggable IDs in tagging conditions](https://github.com/mbleigh/acts-as-taggable-on/pull/1053)
+
 ### [v8.1.0) / 2021-06-19](https://github.com/mbleigh/acts-as-taggable-on/compare/v8.0.0...v8.1.0)
 * Fixes
  * [@ngouy Fix rollbackable tenant migrations](https://github.com/mbleigh/acts-as-taggable-on/pull/1038)
@@ -20,7 +24,7 @@ As such, _Breaking Changes_ are major. _Features_ would map to either major or m
   * [@lunaru Support tenants for taggings](https://github.com/mbleigh/acts-as-taggable-on/pull/1000)
 * Fixes
   * [@gr-eg Use none? instead of count.zero?](https://github.com/mbleigh/acts-as-taggable-on/pull/1030)
-  
+
 ### [v7.0.0) / 2020-12-31](https://github.com/mbleigh/acts-as-taggable-on/compare/v6.5.0...v7.0.0)
 * Features
   * [@kvokka Rails 6.1 support](https://github.com/mbleigh/acts-as-taggable-on/pull/1013)

--- a/lib/acts_as_taggable_on/taggable/collection.rb
+++ b/lib/acts_as_taggable_on/taggable/collection.rb
@@ -153,7 +153,14 @@ module ActsAsTaggableOn::Taggable
 
         taggable_conditions = sanitize_sql(["#{ActsAsTaggableOn::Tagging.table_name}.taggable_type = ?", base_class.name])
         taggable_conditions << sanitize_sql([" AND #{ActsAsTaggableOn::Tagging.table_name}.context = ?", options.delete(:on).to_s]) if options[:on]
-        taggable_conditions << sanitize_sql([" AND #{ActsAsTaggableOn::Tagging.table_name}.taggable_id = ?", options[:id]]) if options[:id]
+
+        if options[:id]
+          if options[:id].is_a? Array
+            taggable_conditions << sanitize_sql([" AND #{ActsAsTaggableOn::Tagging.table_name}.taggable_id IN (?)", options[:id]])
+          else
+            taggable_conditions << sanitize_sql([" AND #{ActsAsTaggableOn::Tagging.table_name}.taggable_id = ?", options[:id]])
+          end
+        end
 
         tagging_conditions.push taggable_conditions
 

--- a/lib/acts_as_taggable_on/version.rb
+++ b/lib/acts_as_taggable_on/version.rb
@@ -1,3 +1,3 @@
 module ActsAsTaggableOn
-  VERSION = '8.2.0'
+  VERSION = '9.0.0'
 end

--- a/lib/acts_as_taggable_on/version.rb
+++ b/lib/acts_as_taggable_on/version.rb
@@ -1,3 +1,3 @@
 module ActsAsTaggableOn
-  VERSION = '8.1.0'
+  VERSION = '8.2.0'
 end


### PR DESCRIPTION
In the event of trying to fetch tags for multiple records, where the IDs of those records are already known, adding support for the `:id` option to accept an array of IDs to use directly, instead of using a subquery to find the same list of IDs.

I had run into a situation, where I was trying to get the tags for a series of records associated to the ones I was listing, and SQL resulting from calling `tag_counts_on` was using a subquery to fetch the IDs that were already being used in the query chain.

For example, say I was listing cases for multiple projects, and wanted to be able to filter those cases by tags on the projects.  If I did:

```ruby
Project.where(id: cases.distinct.pluck(:project_id)).tag_counts_on(:tags)
```

... it would result in a SQL that used the following sub-query:

```sql
AND taggings.taggable_id IN (
  SELECT "projects"."id"
  FROM "projects"
  WHERE "projects"."id" IN ({list of IDs})
)
```

This is causing the database to do extra work.  There's an option that can be used to pass in an ID to `tag_counts_on`, but it currently only works with a single ID.  This PR aims to extend that option to support an array of IDs as well, so the following could be used:

```ruby
Project.tag_counts_on(:tags, id: cases.distinct.pluck(:project_id))
```

... and have the generated SQL be this instead:

```sql
AND taggings.taggable_id IN ({list of IDs})
```