### PR TITLE
chore: Add docker-compose.yml

### DIFF
--- a/acts-as-taggable-on.gemspec
+++ b/acts-as-taggable-on.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
   gem.files         = `git ls-files`.split($/)
   gem.test_files    = gem.files.grep(%r{^spec/})
   gem.require_paths = ['lib']
-  gem.required_ruby_version     = '>= 2.3.7'
+  gem.required_ruby_version     = '>= 2.5.0'
 
   if File.exist?('UPGRADING.md')
     gem.post_install_message = File.read('UPGRADING.md')

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+version: '3.9'
+services:
+  postgres:
+    image: postgres:10
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_DB: acts_as_taggable_on
+      POSTGRES_PASSWORD: postgres
+    ports: ['5432:5432']
+  mysql:
+    image: mysql:8
+    environment:
+      MYSQL_ALLOW_EMPTY_PASSWORD: true
+      MYSQL_DATABASE: acts_as_taggable_on
+    ports: ['3306:3306']

--- a/lib/acts_as_taggable_on/taggable/core.rb
+++ b/lib/acts_as_taggable_on/taggable/core.rb
@@ -51,12 +51,8 @@ module ActsAsTaggableOn::Taggable
               parsed_new_list = ActsAsTaggableOn.default_parser.new(new_tags).parse
 
               if self.class.preserve_tag_order? || (parsed_new_list.sort != #{tag_type}_list.sort)
-                if ActsAsTaggableOn::Utils.legacy_activerecord?
-                  set_attribute_was("#{tag_type}_list", #{tag_type}_list)
-                else
-                  unless #{tag_type}_list_changed?
-                    @attributes["#{tag_type}_list"] = ActiveModel::Attribute.from_user("#{tag_type}_list", #{tag_type}_list, ActsAsTaggableOn::Taggable::TagListType.new)
-                  end
+                unless #{tag_type}_list_changed?
+                  @attributes["#{tag_type}_list"] = ActiveModel::Attribute.from_user("#{tag_type}_list", #{tag_type}_list, ActsAsTaggableOn::Taggable::TagListType.new)
                 end
                 write_attribute("#{tag_type}_list", parsed_new_list)
               end

--- a/spec/support/database.rb
+++ b/spec/support/database.rb
@@ -5,12 +5,17 @@ database_yml = File.expand_path('../../internal/config/database.yml', __FILE__)
 
 if File.exist?(database_yml)
 
-  ActiveRecord::Migration.verbose = false
-  ActiveRecord::Base.default_timezone = :utc
   ActiveRecord::Base.configurations = YAML.load_file(database_yml)
   ActiveRecord::Base.logger = Logger.new(File.join(File.dirname(__FILE__), '../debug.log'))
   ActiveRecord::Base.logger.level = ENV['TRAVIS'] ? ::Logger::ERROR : ::Logger::DEBUG
-  config = ActiveSupport::HashWithIndifferentAccess.new(ActiveRecord::Base.configurations[db_name])
+  ActiveRecord::Migration.verbose = false
+  if ActiveRecord.version >= Gem::Version.new('7.0.0.alpha2')
+    ActiveRecord.default_timezone = :utc
+    config = ActiveRecord::Base.configurations.configs_for(env_name: db_name)
+  else
+    ActiveRecord::Base.default_timezone = :utc
+    config = ActiveSupport::HashWithIndifferentAccess.new(ActiveRecord::Base.configurations[db_name])
+  end
 
   begin
     ActiveRecord::Base.establish_connection(db_name.to_sym)


### PR DESCRIPTION
Adding docker allows contributors to tests every supported databases without the need to install them in their machines.

This will help also current pull-requests authors that implemented a feature that might not be stable/working in other database system.