### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ was used.
 To use it, add it to your Gemfile:
 
 ```ruby
-gem 'acts-as-taggable-on', '~> 9.0'
+gem 'acts-as-taggable-on', '~> 8.0'
 ```
 
 and bundle:


### PR DESCRIPTION
AATO version 9.0 does not seem to exist, changing recommended gemfile version to v8