### PR TITLE
chore: remove legacy migration syntax

### DIFF
--- a/db/migrate/1_acts_as_taggable_on_migration.rb
+++ b/db/migrate/1_acts_as_taggable_on_migration.rb
@@ -1,9 +1,6 @@
-if ActiveRecord.gem_version >= Gem::Version.new('5.0')
-  class ActsAsTaggableOnMigration < ActiveRecord::Migration[4.2]; end
-else
-  class ActsAsTaggableOnMigration < ActiveRecord::Migration; end
-end
-ActsAsTaggableOnMigration.class_eval do
+# frozen_string_literal: true
+
+class ActsAsTaggableOnMigration < ActiveRecord::Migration[6.0]
   def self.up
     create_table ActsAsTaggableOn.tags_table do |t|
       t.string :name
@@ -26,7 +23,8 @@ ActsAsTaggableOnMigration.class_eval do
     end
 
     add_index ActsAsTaggableOn.taggings_table, :tag_id
-    add_index ActsAsTaggableOn.taggings_table, [:taggable_id, :taggable_type, :context], name: 'taggings_taggable_context_idx'
+    add_index ActsAsTaggableOn.taggings_table, %i[taggable_id taggable_type context],
+              name: 'taggings_taggable_context_idx'
   end
 
   def self.down

--- a/db/migrate/2_add_missing_unique_indices.rb
+++ b/db/migrate/2_add_missing_unique_indices.rb
@@ -1,16 +1,13 @@
-if ActiveRecord.gem_version >= Gem::Version.new('5.0')
-  class AddMissingUniqueIndices < ActiveRecord::Migration[4.2]; end
-else
-  class AddMissingUniqueIndices < ActiveRecord::Migration; end
-end
-AddMissingUniqueIndices.class_eval do
+# frozen_string_literal: true
+
+class AddMissingUniqueIndices < ActiveRecord::Migration[6.0]
   def self.up
     add_index ActsAsTaggableOn.tags_table, :name, unique: true
 
     remove_index ActsAsTaggableOn.taggings_table, :tag_id if index_exists?(ActsAsTaggableOn.taggings_table, :tag_id)
     remove_index ActsAsTaggableOn.taggings_table, name: 'taggings_taggable_context_idx'
     add_index ActsAsTaggableOn.taggings_table,
-              [:tag_id, :taggable_id, :taggable_type, :context, :tagger_id, :tagger_type],
+              %i[tag_id taggable_id taggable_type context tagger_id tagger_type],
               unique: true, name: 'taggings_idx'
   end
 
@@ -20,6 +17,7 @@ AddMissingUniqueIndices.class_eval do
     remove_index ActsAsTaggableOn.taggings_table, name: 'taggings_idx'
 
     add_index ActsAsTaggableOn.taggings_table, :tag_id unless index_exists?(ActsAsTaggableOn.taggings_table, :tag_id)
-    add_index ActsAsTaggableOn.taggings_table, [:taggable_id, :taggable_type, :context], name: 'taggings_taggable_context_idx'
+    add_index ActsAsTaggableOn.taggings_table, %i[taggable_id taggable_type context],
+              name: 'taggings_taggable_context_idx'
   end
 end

--- a/db/migrate/3_add_taggings_counter_cache_to_tags.rb
+++ b/db/migrate/3_add_taggings_counter_cache_to_tags.rb
@@ -1,9 +1,6 @@
-if ActiveRecord.gem_version >= Gem::Version.new('5.0')
-  class AddTaggingsCounterCacheToTags < ActiveRecord::Migration[4.2]; end
-else
-  class AddTaggingsCounterCacheToTags < ActiveRecord::Migration; end
-end
-AddTaggingsCounterCacheToTags.class_eval do
+# frozen_string_literal: true
+
+class AddTaggingsCounterCacheToTags < ActiveRecord::Migration[6.0]
   def self.up
     add_column ActsAsTaggableOn.tags_table, :taggings_count, :integer, default: 0
 

--- a/db/migrate/4_add_missing_taggable_index.rb
+++ b/db/migrate/4_add_missing_taggable_index.rb
@@ -1,11 +1,9 @@
-if ActiveRecord.gem_version >= Gem::Version.new('5.0')
-  class AddMissingTaggableIndex < ActiveRecord::Migration[4.2]; end
-else
-  class AddMissingTaggableIndex < ActiveRecord::Migration; end
-end
-AddMissingTaggableIndex.class_eval do
+# frozen_string_literal: true
+
+class AddMissingTaggableIndex < ActiveRecord::Migration[6.0]
   def self.up
-    add_index ActsAsTaggableOn.taggings_table, [:taggable_id, :taggable_type, :context], name: 'taggings_taggable_context_idx'
+    add_index ActsAsTaggableOn.taggings_table, %i[taggable_id taggable_type context],
+              name: 'taggings_taggable_context_idx'
   end
 
   def self.down

--- a/db/migrate/5_change_collation_for_tag_names.rb
+++ b/db/migrate/5_change_collation_for_tag_names.rb
@@ -1,11 +1,9 @@
+# frozen_string_literal: true
+
 # This migration is added to circumvent issue #623 and have special characters
 # work properly
-if ActiveRecord.gem_version >= Gem::Version.new('5.0')
-  class ChangeCollationForTagNames < ActiveRecord::Migration[4.2]; end
-else
-  class ChangeCollationForTagNames < ActiveRecord::Migration; end
-end
-ChangeCollationForTagNames.class_eval do
+
+class ChangeCollationForTagNames < ActiveRecord::Migration[6.0]
   def up
     if ActsAsTaggableOn::Utils.using_mysql?
       execute("ALTER TABLE #{ActsAsTaggableOn.tags_table} MODIFY name varchar(255) CHARACTER SET utf8 COLLATE utf8_bin;")

--- a/db/migrate/6_add_missing_indexes_on_taggings.rb
+++ b/db/migrate/6_add_missing_indexes_on_taggings.rb
@@ -1,22 +1,24 @@
-if ActiveRecord.gem_version >= Gem::Version.new('5.0')
-  class AddMissingIndexesOnTaggings < ActiveRecord::Migration[4.2]; end
-else
-  class AddMissingIndexesOnTaggings < ActiveRecord::Migration; end
-end
-AddMissingIndexesOnTaggings.class_eval do
+# frozen_string_literal: true
+
+class AddMissingIndexesOnTaggings < ActiveRecord::Migration[6.0]
   def change
     add_index ActsAsTaggableOn.taggings_table, :tag_id unless index_exists? ActsAsTaggableOn.taggings_table, :tag_id
-    add_index ActsAsTaggableOn.taggings_table, :taggable_id unless index_exists? ActsAsTaggableOn.taggings_table, :taggable_id
-    add_index ActsAsTaggableOn.taggings_table, :taggable_type unless index_exists? ActsAsTaggableOn.taggings_table, :taggable_type
-    add_index ActsAsTaggableOn.taggings_table, :tagger_id unless index_exists? ActsAsTaggableOn.taggings_table, :tagger_id
+    add_index ActsAsTaggableOn.taggings_table, :taggable_id unless index_exists? ActsAsTaggableOn.taggings_table,
+                                                                                 :taggable_id
+    add_index ActsAsTaggableOn.taggings_table, :taggable_type unless index_exists? ActsAsTaggableOn.taggings_table,
+                                                                                   :taggable_type
+    add_index ActsAsTaggableOn.taggings_table, :tagger_id unless index_exists? ActsAsTaggableOn.taggings_table,
+                                                                               :tagger_id
     add_index ActsAsTaggableOn.taggings_table, :context unless index_exists? ActsAsTaggableOn.taggings_table, :context
 
-    unless index_exists? ActsAsTaggableOn.taggings_table, [:tagger_id, :tagger_type]
-      add_index ActsAsTaggableOn.taggings_table, [:tagger_id, :tagger_type]
+    unless index_exists? ActsAsTaggableOn.taggings_table, %i[tagger_id tagger_type]
+      add_index ActsAsTaggableOn.taggings_table, %i[tagger_id tagger_type]
     end
 
-    unless index_exists? ActsAsTaggableOn.taggings_table, [:taggable_id, :taggable_type, :tagger_id, :context], name: 'taggings_idy'
-      add_index ActsAsTaggableOn.taggings_table, [:taggable_id, :taggable_type, :tagger_id, :context], name: 'taggings_idy'
+    unless index_exists? ActsAsTaggableOn.taggings_table, %i[taggable_id taggable_type tagger_id context],
+                         name: 'taggings_idy'
+      add_index ActsAsTaggableOn.taggings_table, %i[taggable_id taggable_type tagger_id context],
+                name: 'taggings_idy'
     end
   end
 end

--- a/db/migrate/7_add_tenant_to_taggings.rb
+++ b/db/migrate/7_add_tenant_to_taggings.rb
@@ -1,9 +1,6 @@
-if ActiveRecord.gem_version >= Gem::Version.new('5.0')
-  class AddTenantToTaggings < ActiveRecord::Migration[4.2]; end
-else
-  class AddTenantToTaggings < ActiveRecord::Migration; end
-end
-AddTenantToTaggings.class_eval do
+# frozen_string_literal: true
+
+class AddTenantToTaggings < ActiveRecord::Migration[6.0]
   def self.up
     add_column ActsAsTaggableOn.taggings_table, :tenant, :string, limit: 128
     add_index ActsAsTaggableOn.taggings_table, :tenant unless index_exists? ActsAsTaggableOn.taggings_table, :tenant


### PR DESCRIPTION
We don't support activerecord prior 4.2, so the syntax hack is not needed anymore.