### PR TITLE
Handle RecordNotUnique error in find_or_create_all_with_like_by_name correctly

### DIFF
--- a/lib/acts_as_taggable_on/tag.rb
+++ b/lib/acts_as_taggable_on/tag.rb
@@ -84,10 +84,11 @@ module ActsAsTaggableOn
         tries ||= 3
         comparable_tag_name = comparable_name(tag_name)
         existing_tag = existing_tags.find { |tag| comparable_name(tag.name) == comparable_tag_name }
-        existing_tag || create(name: tag_name)
+        next existing_tag if existing_tag
+
+        transaction(requires_new: true) { create(name: tag_name) }
       rescue ActiveRecord::RecordNotUnique
         if (tries -= 1).positive?
-          ActiveRecord::Base.connection.execute 'ROLLBACK'
           existing_tags = named_any(list)
           retry
         end

--- a/spec/support/database_cleaner.rb
+++ b/spec/support/database_cleaner.rb
@@ -6,6 +6,10 @@ RSpec.configure do |config|
     DatabaseCleaner.clean
   end
 
+  config.before(:each, :database_cleaner_delete) do
+    DatabaseCleaner.strategy = :truncation
+  end
+
   config.after(:suite) do
     DatabaseCleaner.clean
   end


### PR DESCRIPTION
Related to https://github.com/mbleigh/acts-as-taggable-on/issues/1068, https://github.com/mbleigh/acts-as-taggable-on/issues/948

In the find_or_create_all_with_like_by_name method,
instead of issuing a ROLLBACK statement, we wrap the tag creation in a
transaction instead.

Issuing a ROLLBACK will break nested transactions, and also does not
respect multiple databases (available since Rails 6).

Adds a spec which attempts to simulate concurrent tag creation