### PR TITLE
Fix `base_class` with Zeitwerk

### DIFF
--- a/lib/acts-as-taggable-on.rb
+++ b/lib/acts-as-taggable-on.rb
@@ -79,7 +79,7 @@ module ActsAsTaggableOn
       @force_binary_collation = false
       @tags_table = :tags
       @taggings_table = :taggings
-      @base_class = ::ActiveRecord::Base
+      @base_class = '::ActiveRecord::Base'
     end
 
     def strict_case_match=(force_cs)
@@ -121,7 +121,7 @@ WARNING
     end
 
     def base_class=(base_class)
-      raise "base_class must be a class constant" unless base_class.is_a?(Class)
+      raise "base_class must be a String" unless base_class.is_a?(String)
       @base_class = base_class
     end
 

--- a/lib/acts_as_taggable_on/tag.rb
+++ b/lib/acts_as_taggable_on/tag.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module ActsAsTaggableOn
-  class Tag < ActsAsTaggableOn.base_class
+  class Tag < ActsAsTaggableOn.base_class.constantize
     self.table_name = ActsAsTaggableOn.tags_table
 
     ### ASSOCIATIONS:

--- a/lib/acts_as_taggable_on/tagging.rb
+++ b/lib/acts_as_taggable_on/tagging.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module ActsAsTaggableOn
-  class Tagging < ActsAsTaggableOn.base_class # :nodoc:
+  class Tagging < ActsAsTaggableOn.base_class.constantize # :nodoc:
     self.table_name = ActsAsTaggableOn.taggings_table
 
     DEFAULT_CONTEXT = 'tags'

--- a/lib/tasks/example/acts_as_taggable_on.rb.example
+++ b/lib/tasks/example/acts_as_taggable_on.rb.example
@@ -1,4 +1,8 @@
-# This works because the classes where the base class is a concern, Tag and Tagging
-# are autoloaded, and won't be started until after the initializers run.
-
-# ActsAsTaggableOn.base_class = ApplicationRecord
+ActsAsTaggableOn.setup do |config|
+  # This works because the classes where the base class is a concern, Tag and Tagging
+  # are autoloaded, and won't be started until after the initializers run. The value
+  # must be a String, as the Rails Zeitwerk autoloader will not allow models to be
+  # referenced at initialization time.
+  #
+  # config.base_class = 'ApplicationRecord'
+end

--- a/spec/acts_as_taggable_on/tag_spec.rb
+++ b/spec/acts_as_taggable_on/tag_spec.rb
@@ -368,7 +368,7 @@ describe ActsAsTaggableOn::Tag do
     context "custom" do
       it "inherits from custom class" do
 
-        ActsAsTaggableOn.base_class = Foo
+        ActsAsTaggableOn.base_class = 'Foo'
         hide_const("ActsAsTaggableOn::Tag")
         load("lib/acts_as_taggable_on/tag.rb")
 

--- a/spec/acts_as_taggable_on/tagging_spec.rb
+++ b/spec/acts_as_taggable_on/tagging_spec.rb
@@ -157,7 +157,7 @@ describe ActsAsTaggableOn::Tagging do
     context "custom" do
       it "inherits from custom class" do
 
-        ActsAsTaggableOn.base_class = Foo
+        ActsAsTaggableOn.base_class = 'Foo'
         hide_const("ActsAsTaggableOn::Tagging")
         load("lib/acts_as_taggable_on/tagging.rb")
 


### PR DESCRIPTION
Rails [Zeitwerk](https://github.com/fxn/zeitwerk) autoloader is a lot more strict about when constants are loaded than the old autoloader. I noticed that in https://github.com/mbleigh/acts-as-taggable-on/pull/1079 `base_class` is being set to the actual class in an initializer, which results in an `unintialized constant` error when the autoloader is set to Zeitwerk. This fixes the setting to work in Zeitwerk by allowing it to be set to a `String` which gets constantized later, after initializers have run.

I also fixed the initializer example to call the `setup` method, which I believe is the recommended way to do that.