### PR TITLE
Remove redundant indexes created by the default migration files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ As such, _Breaking Changes_ are major. _Features_ would map to either major or m
 * Features
   * [@glampr Add support for prefix and suffix searches alongside previously supported containment (wildcard) searches](https://github.com/mbleigh/acts-as-taggable-on/pull/1082)
   * [@donquxiote Add support for horizontally sharded databases](https://github.com/mbleigh/acts-as-taggable-on/pull/1079)
+* Fixes
+  * Remove redundant indexes
 
 ### [v9.0.1) / 2022-01-07](https://github.com/mbleigh/acts-as-taggable-on/compare/v9.0.0..v9.0.1)
 * Fixes

--- a/db/migrate/6_add_missing_indexes_on_taggings.rb
+++ b/db/migrate/6_add_missing_indexes_on_taggings.rb
@@ -2,13 +2,6 @@
 
 class AddMissingIndexesOnTaggings < ActiveRecord::Migration[6.0]
   def change
-    add_index ActsAsTaggableOn.taggings_table, :tag_id unless index_exists? ActsAsTaggableOn.taggings_table, :tag_id
-    add_index ActsAsTaggableOn.taggings_table, :taggable_id unless index_exists? ActsAsTaggableOn.taggings_table,
-                                                                                 :taggable_id
-    add_index ActsAsTaggableOn.taggings_table, :taggable_type unless index_exists? ActsAsTaggableOn.taggings_table,
-                                                                                   :taggable_type
-    add_index ActsAsTaggableOn.taggings_table, :tagger_id unless index_exists? ActsAsTaggableOn.taggings_table,
-                                                                               :tagger_id
     add_index ActsAsTaggableOn.taggings_table, :context unless index_exists? ActsAsTaggableOn.taggings_table, :context
 
     unless index_exists? ActsAsTaggableOn.taggings_table, %i[tagger_id tagger_type]

--- a/spec/internal/db/schema.rb
+++ b/spec/internal/db/schema.rb
@@ -28,7 +28,6 @@ ActiveRecord::Schema.define version: 0 do
   add_index ActsAsTaggableOn.taggings_table,
             ['tag_id', 'taggable_id', 'taggable_type', 'context', 'tagger_id', 'tagger_type'],
             unique: true, name: 'taggings_idx'
-  add_index ActsAsTaggableOn.taggings_table, :tag_id , name: 'index_taggings_on_tag_id'
 
   # above copied from
   # generators/acts_as_taggable_on/migration/migration_generator


### PR DESCRIPTION
**Context**
Several redundant indexes are created by the default migration files generated
Issue: https://github.com/mbleigh/acts-as-taggable-on/issues/1083

**Solution**
- remove index_taggings_on_tag_id - can be replaced by taggings_idx
- remove index_taggings_on_taggable_id - can be replaced by taggings_idy or taggings_taggable_context_idx
- remove index_taggings_on_taggable_type - can be replaced by index_taggings_on_taggable_type_and_taggable_id
- remove index_taggings_on_tagger_id - can be replaced by index_taggings_on_tagger_id_and_tagger_type