### PR TITLE
Use eq instead of matches for non-wildcard searches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ As such, _Breaking Changes_ are major. _Features_ would map to either major or m
 * Features
   * [@glampr Add support for prefix and suffix searches alongside previously supported containment (wildcard) searches](https://github.com/mbleigh/acts-as-taggable-on/pull/1082)
   * [@donquxiote Add support for horizontally sharded databases](https://github.com/mbleigh/acts-as-taggable-on/pull/1079)
+* Fixes
+  * [@flickgradley Use eq instead of matches for non-wildcard searches](https://github.com/mbleigh/acts-as-taggable-on/pull/1101)
 
 ### [v9.0.1) / 2022-01-07](https://github.com/mbleigh/acts-as-taggable-on/compare/v9.0.0..v9.0.1)
 * Fixes

--- a/lib/acts_as_taggable_on/taggable/tagged_with_query/query_base.rb
+++ b/lib/acts_as_taggable_on/taggable/tagged_with_query/query_base.rb
@@ -35,7 +35,8 @@ module ActsAsTaggableOn
           if options[:wild].present?
             matches_attribute.matches(wildcard_escaped_tag(tag), '!', ActsAsTaggableOn.strict_case_match)
           else
-            matches_attribute.matches(escaped_tag(tag), '!', ActsAsTaggableOn.strict_case_match)
+            tag = tag.downcase unless ActsAsTaggableOn.strict_case_match
+            matches_attribute.eq(tag)
           end
         end
 
@@ -48,9 +49,9 @@ module ActsAsTaggableOn
                                             wildcard_escaped_tag(tag)
                                           end, '!', ActsAsTaggableOn.strict_case_match)
           else
-            matches_attribute.matches_any(tag_list.map do |tag|
-                                            escaped_tag(tag).to_s
-                                          end, '!', ActsAsTaggableOn.strict_case_match)
+            matches_attribute.eq_any(tag_list.map do |tag|
+                                       ActsAsTaggableOn.strict_case_match ? tag : tag.downcase
+                                     end)
           end
         end
 


### PR DESCRIPTION
**Context:**

Thanks for such an excellent gem! We have over 60,000 tags in our database, and optimizing the LIKE and ILIKE operators is proving to be difficult. It seems like we don't need to use LIKE/ILIKE when doing exact tag matches (non-wildcard) - this PR changes the `matches` and `matches_any` operators to `eq` and `eq_any`, which would let us use a BTREE index on lower(name) to optimize these queries. We already use lower(name) when performing a case-insensitive search, so we don't need to use ILIKE as well.