### PR TITLE
Add tenant: option to tagged_with

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ As such, _Breaking Changes_ are major. _Features_ would map to either major or m
 * Features
   * [@glampr Add support for prefix and suffix searches alongside previously supported containment (wildcard) searches](https://github.com/mbleigh/acts-as-taggable-on/pull/1082)
   * [@donquxiote Add support for horizontally sharded databases](https://github.com/mbleigh/acts-as-taggable-on/pull/1079)
+  * [@flickgradley Add tenant: option to tagged_with](https://github.com/mbleigh/acts-as-taggable-on/pull/1102)
 
 ### [v9.0.1) / 2022-01-07](https://github.com/mbleigh/acts-as-taggable-on/compare/v9.0.0..v9.0.1)
 * Fixes

--- a/lib/acts_as_taggable_on/taggable/core.rb
+++ b/lib/acts_as_taggable_on/taggable/core.rb
@@ -97,6 +97,7 @@ module ActsAsTaggableOn
         #                       * <tt>:owned_by</tt> - return objects that are *ONLY* owned by the owner
         #                       * <tt>:start_at</tt> - Restrict the tags to those created after a certain time
         #                       * <tt>:end_at</tt> - Restrict the tags to those created before a certain time
+        #                       * <tt>:tenant</tt> - *ONLY* consider tags with a given tenant
         #
         # Example:
         #   User.tagged_with(["awesome", "cool"])                     # Users that are tagged with awesome and cool
@@ -106,6 +107,9 @@ module ActsAsTaggableOn
         #   User.tagged_with(["awesome", "cool"], :match_all => true) # Users that are tagged with just awesome and cool
         #   User.tagged_with(["awesome", "cool"], :owned_by => foo ) # Users that are tagged with just awesome and cool by 'foo'
         #   User.tagged_with(["awesome", "cool"], :owned_by => foo, :start_at => Date.today ) # Users that are tagged with just awesome, cool by 'foo' and starting today
+        #   User.tagged_with(["awesome", "cool"], :tenant => "account_15") # Users that are tagged with awesome and cool within the "account_15" tenant
+        #   User.tagged_with(["awesome", "cool"], :tenant => "account_15", :any => true ) # Users that are tagged with awesome or cool within the "account_15" tenant
+        #   User.tagged_with(["awesome", "cool"], :tenant => "account_15", :exclude => true ) # Users that are not tagged with awesome or cool within the "account_15" tenant
         def tagged_with(tags, options = {})
           tag_list = ActsAsTaggableOn.default_parser.new(tags).parse
           options = options.dup

--- a/lib/acts_as_taggable_on/taggable/tagged_with_query/all_tags_query.rb
+++ b/lib/acts_as_taggable_on/taggable/tagged_with_query/all_tags_query.rb
@@ -59,6 +59,10 @@ module ActsAsTaggableOn
                                        .and(tagging_alias[:tagger_type].eq(owner.class.base_class.to_s))
           end
 
+          if options[:tenant].present?
+            on_condition = on_condition.and(tagging_alias[:tenant].eq(options[:tenant]))
+          end
+
           on_condition
         end
 

--- a/lib/acts_as_taggable_on/taggable/tagged_with_query/any_tags_query.rb
+++ b/lib/acts_as_taggable_on/taggable/tagged_with_query/any_tags_query.rb
@@ -47,6 +47,10 @@ module ActsAsTaggableOn
                                                .and(tagging_arel_table[:tagger_type].eq(owner.class.base_class.to_s))
           end
 
+          if options[:tenant].present?
+            exists_contition = exists_contition.and(tagging_arel_table[:tenant].eq(options[:tenant]))
+          end
+
           exists_contition
         end
 


### PR DESCRIPTION
To improve multi tenancy support, I thought it would be good to add a `tenant:` option to the `tagged_with` query. We have 1.2M tagged objects in our database, and adding this tenant filter to that query should make it significantly faster to find objects tagged within a certain tenant.