### PR TITLE
Fix foreign key issue in migration

### DIFF
--- a/db/migrate/2_add_missing_unique_indices.rb
+++ b/db/migrate/2_add_missing_unique_indices.rb
@@ -4,11 +4,13 @@ class AddMissingUniqueIndices < ActiveRecord::Migration[6.0]
   def self.up
     add_index ActsAsTaggableOn.tags_table, :name, unique: true
 
+    remove_foreign_key ActsAsTaggableOn.taggings_table, :tags if foreign_key_exists?(ActsAsTaggableOn.taggings_table, :tags)
     remove_index ActsAsTaggableOn.taggings_table, :tag_id if index_exists?(ActsAsTaggableOn.taggings_table, :tag_id)
     remove_index ActsAsTaggableOn.taggings_table, name: 'taggings_taggable_context_idx'
     add_index ActsAsTaggableOn.taggings_table,
               %i[tag_id taggable_id taggable_type context tagger_id tagger_type],
               unique: true, name: 'taggings_idx'
+    add_foreign_key ActsAsTaggableOn.taggings_table, ActsAsTaggableOn.tags_table, column: :tag_id
   end
 
   def self.down


### PR DESCRIPTION
Hey, I've noticed that if we run the migrations generated by this gem using a MySQL database we get an error that prevents the migration from being run successfully.
Specifically, when the `AddMissingUniqueIndices` migration runs, we try to remove the `tag_id` index from the `taggings` table, but it fails because we have the foreign key on `tags(id)`.

I've encountered this problem with MySQL 5.7 (the most used nowadays), 8.0.32, and 8.0.33.

This is the error:
```bash
$ rake db:migrate
== 20230812090522 ActsAsTaggableOnMigration: migrating ========================
-- create_table(:tags, {})
   -> 0.0800s
-- create_table(:taggings, {})
   -> 0.0273s
-- add_index(:taggings, [:taggable_id, :taggable_type, :context], {:name=>"taggings_taggable_context_idx"})
   -> 0.0345s
== 20230812090522 ActsAsTaggableOnMigration: migrated (0.1421s) ===============

== 20230812090523 AddMissingUniqueIndices: migrating ==========================
-- add_index(:tags, :name, {:unique=>true})
   -> 0.0268s
-- index_exists?(:taggings, :tag_id)
   -> 0.0005s
-- remove_index(:taggings, :tag_id)
rake aborted!
StandardError: An error has occurred, all later migrations canceled:

Mysql2::Error: Cannot drop index 'index_taggings_on_tag_id': needed in a foreign key constraint
/Users/francesco.mari/workspace-offline/shop/db/migrate/20230812090523_add_missing_unique_indices.acts_as_taggable_on_engine.rb:8:in `up'

Caused by:
ActiveRecord::StatementInvalid: Mysql2::Error: Cannot drop index 'index_taggings_on_tag_id': needed in a foreign key constraint
/Users/francesco.mari/workspace-offline/shop/db/migrate/20230812090523_add_missing_unique_indices.acts_as_taggable_on_engine.rb:8:in `up'

Caused by:
Mysql2::Error: Cannot drop index 'index_taggings_on_tag_id': needed in a foreign key constraint
/Users/francesco.mari/workspace-offline/shop/db/migrate/20230812090523_add_missing_unique_indices.acts_as_taggable_on_engine.rb:8:in `up'
Tasks: TOP => db:migrate
(See full trace by running task with --trace)
```

With this fix we remove the foreign key before the offending line, and add it again at the end, after we create the compound index.