### PR TITLE
Prepare release V10 release

### DIFF
--- a/.github/workflows/spec.yml
+++ b/.github/workflows/spec.yml
@@ -60,7 +60,7 @@ jobs:
           --health-timeout 5s
           --health-retries 5
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:

--- a/.github/workflows/spec.yml
+++ b/.github/workflows/spec.yml
@@ -17,12 +17,10 @@ jobs:
           - 3.1
           - "3.0"
           - 2.7
-          - 2.6
-          - 2.5
         gemfile:
-          - gemfiles/activerecord_6.0.gemfile
-          - gemfiles/activerecord_6.1.gemfile
+          - gemfiles/activerecord_7.1.gemfile
           - gemfiles/activerecord_7.0.gemfile
+          - gemfiles/activerecord_6.1.gemfile
         db:
           - mysql
           - postgresql
@@ -35,10 +33,6 @@ jobs:
             db: postgresql
             gemfile: gemfiles/activerecord_7.0.gemfile
         exclude:
-          - ruby: 2.5
-            gemfile: gemfiles/activerecord_7.0.gemfile
-          - ruby: 2.6
-            gemfile: gemfiles/activerecord_7.0.gemfile
           - ruby: 3.2
             gemfile: gemfiles/activerecord_6.0.gemfile
 

--- a/Appraisals
+++ b/Appraisals
@@ -1,11 +1,5 @@
 # frozen_string_literal: true
 
-appraise 'activerecord-6.0' do
-  gem 'activerecord', '~> 6.0.0'
-  gem 'pg'
-  gem 'mysql2', '~> 0.5'
-end
-
 appraise 'activerecord-6.1' do
   gem 'activerecord', '~> 6.1.0'
   gem 'pg'
@@ -16,4 +10,16 @@ appraise 'activerecord-7.0' do
   gem 'activerecord', '~> 7.0.1'
   gem 'pg'
   gem 'mysql2', '~> 0.5'
+end
+
+appraise 'activerecord-7.1' do
+    gem 'activerecord', '~> 7.1.0'
+    gem 'pg'
+    gem 'mysql2', '~> 0.5'
+end
+
+appraise 'activerecord-7.1' do
+    gem 'activerecord', '~> 7.1.0'
+    gem 'pg'
+    gem 'trilogy'
 end

--- a/Appraisals
+++ b/Appraisals
@@ -17,9 +17,3 @@ appraise 'activerecord-7.1' do
     gem 'pg'
     gem 'mysql2', '~> 0.5'
 end
-
-appraise 'activerecord-7.1' do
-    gem 'activerecord', '~> 7.1.0'
-    gem 'pg'
-    gem 'trilogy'
-end

--- a/Appraisals
+++ b/Appraisals
@@ -13,7 +13,7 @@ appraise 'activerecord-7.0' do
 end
 
 appraise 'activerecord-7.1' do
-    gem 'activerecord', '~> 7.1.0'
-    gem 'pg'
-    gem 'mysql2', '~> 0.5'
+  gem 'activerecord', '~> 7.1.0'
+  gem 'pg'
+  gem 'mysql2', '~> 0.5'
 end

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Each change should fall into categories that would affect whether the release is
 
 As such, _Breaking Changes_ are major. _Features_ would map to either major or minor. _Fixes_, _Performance_, and _Misc_ are either minor or patch, the difference being kind of fuzzy for the purposes of history. Adding _Documentation_ (including tests) would be patch level.
 
-### [v9.1.0) / unreleased](https://github.com/mbleigh/acts-as-taggable-on/compare/v9.0.1...master)
+### [v10.0.0) / unreleased](https://github.com/mbleigh/acts-as-taggable-on/compare/v9.0.1...master)
 * Features
   * [@glampr Add support for prefix and suffix searches alongside previously supported containment (wildcard) searches](https://github.com/mbleigh/acts-as-taggable-on/pull/1082)
   * [@donquxiote Add support for horizontally sharded databases](https://github.com/mbleigh/acts-as-taggable-on/pull/1079)

--- a/acts-as-taggable-on.gemspec
+++ b/acts-as-taggable-on.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |gem|
   gem.files         = `git ls-files`.split($/)
   gem.test_files    = gem.files.grep(%r{^spec/})
   gem.require_paths = ['lib']
-  gem.required_ruby_version     = '>= 2.5.0'
+  gem.required_ruby_version     = '>= 2.7.0'
 
   if File.exist?('UPGRADING.md')
     gem.post_install_message = File.read('UPGRADING.md')

--- a/acts-as-taggable-on.gemspec
+++ b/acts-as-taggable-on.gemspec
@@ -1,7 +1,6 @@
 # coding: utf-8
-lib = File.expand_path('../lib', __FILE__)
-$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require 'acts_as_taggable_on/version'
+
+require_relative 'lib/acts_as_taggable_on/version'
 
 Gem::Specification.new do |gem|
   gem.name          = 'acts-as-taggable-on'
@@ -22,7 +21,7 @@ Gem::Specification.new do |gem|
     gem.post_install_message = File.read('UPGRADING.md')
   end
 
-  gem.add_runtime_dependency 'activerecord', '>= 6.0', '< 8'
+  gem.add_runtime_dependency 'activerecord', '>= 6.1', '< 7.2'
 
   gem.add_development_dependency 'rspec-rails'
   gem.add_development_dependency 'rspec-its'

--- a/gemfiles/activerecord_7.1.gemfile
+++ b/gemfiles/activerecord_7.1.gemfile
@@ -2,9 +2,9 @@
 
 source "https://rubygems.org"
 
-gem "activerecord", "~> 7.0.1"
+gem "activerecord", "~> 7.1.0"
 gem "pg"
-gem "mysql2", "~> 0.5"
+gem "trilogy"
 
 group :local_development do
   gem "guard"

--- a/gemfiles/activerecord_7.1.gemfile
+++ b/gemfiles/activerecord_7.1.gemfile
@@ -4,7 +4,7 @@ source "https://rubygems.org"
 
 gem "activerecord", "~> 7.1.0"
 gem "pg"
-gem "trilogy"
+gem "mysql2", "~> 0.5"
 
 group :local_development do
   gem "guard"

--- a/lib/acts_as_taggable_on/tagger.rb
+++ b/lib/acts_as_taggable_on/tagger.rb
@@ -40,9 +40,7 @@ module ActsAsTaggableOn
         false
       end
 
-      def is_tagger?
-        tagger?
-      end
+      alias is_tagger? tagger?
     end
 
     module InstanceMethods
@@ -75,9 +73,7 @@ module ActsAsTaggableOn
         self.class.is_tagger?
       end
 
-      def is_tagger?
-        tagger?
-      end
+      alias is_tagger? tagger?
     end
 
     module SingletonMethods
@@ -85,9 +81,7 @@ module ActsAsTaggableOn
         true
       end
 
-      def is_tagger?
-        tagger?
-      end
+      alias is_tagger? tagger?
     end
   end
 end

--- a/lib/acts_as_taggable_on/utils.rb
+++ b/lib/acts_as_taggable_on/utils.rb
@@ -26,10 +26,6 @@ module ActsAsTaggableOn
         using_postgresql? ? 'ILIKE' : 'LIKE'
       end
 
-      def legacy_activerecord?
-        ActiveRecord.version <= Gem::Version.new('5.3.0')
-      end
-
       # escape _ and % characters in strings, since these are wildcards in SQL.
       def escape_like(str)
         str.gsub(/[!%_]/) { |x| "!#{x}" }

--- a/lib/acts_as_taggable_on/version.rb
+++ b/lib/acts_as_taggable_on/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ActsAsTaggableOn
-  VERSION = '9.0.1'
+  VERSION = '10.0.0'
 end

--- a/spec/support/database.rb
+++ b/spec/support/database.rb
@@ -18,18 +18,14 @@ if ActiveRecord.version >= Gem::Version.new('7.0.0.alpha2')
 else
   ActiveRecord::Base.default_timezone = :utc
 end
-config = if ActiveRecord.version >= Gem::Version.new('6.1.0')
-           ActiveRecord::Base.configurations.configs_for(env_name: db_name)
-         else
-           ActiveSupport::HashWithIndifferentAccess.new(ActiveRecord::Base.configurations[db_name])
-         end
+config = ActiveRecord::Base.configurations.configs_for(env_name: db_name)
 
 begin
   ActiveRecord::Base.establish_connection(db_name.to_sym)
   ActiveRecord::Base.connection
 rescue StandardError
   case db_name
-  when /mysql/
+  when /(mysql)/
     ActiveRecord::Base.establish_connection(config.merge('database' => nil))
     ActiveRecord::Base.connection.create_database(config['database'],
                                                   { charset: 'utf8', collation: 'utf8_unicode_ci' })


### PR DESCRIPTION
In this version, we will drop support for unsupported versions of rubies and activerecord.

This will allow to remove any backward compatibility hack that was introduced in the code base.