### PR TITLE
Update readme with latest version of the gem

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ was used.
 To use it, add it to your Gemfile:
 
 ```ruby
-gem 'acts-as-taggable-on', '~> 9.0'
+gem 'acts-as-taggable-on'
 ```
 
 and bundle:


### PR DESCRIPTION
I removed `, '~> 9.0'` for everyone to get the latest version of the gem so that people that use Rails 7.1 don't get a version error message. We could add `, '~> 10.0'` instead as well, but it has to be changed at every new version.