### PR TITLE
Performance improvements

### DIFF
--- a/lib/acts_as_taggable_on/taggable/core.rb
+++ b/lib/acts_as_taggable_on/taggable/core.rb
@@ -217,7 +217,7 @@ module ActsAsTaggableOn
       end
 
       def tagging_contexts
-        self.class.tag_types.map(&:to_s) + custom_contexts
+        (self.class.tag_types.map(&:to_s) + custom_contexts).uniq
       end
 
       def taggable_tenant

--- a/lib/acts_as_taggable_on/taggable/ownership.rb
+++ b/lib/acts_as_taggable_on/taggable/ownership.rb
@@ -90,6 +90,7 @@ module ActsAsTaggableOn
         super(*args)
       end
 
+      # This looks duplicated from taggable/core.rb
       def save_owned_tags
         tagging_contexts.each do |context|
           cached_owned_tag_list_on(context).each do |owner, tag_list|

--- a/lib/acts_as_taggable_on/tagging.rb
+++ b/lib/acts_as_taggable_on/tagging.rb
@@ -28,12 +28,15 @@ module ActsAsTaggableOn
     private
 
     def remove_unused_tags
-      if ActsAsTaggableOn.remove_unused_tags
-        if ActsAsTaggableOn.tags_counter
-          tag.destroy if tag.reload.taggings_count.zero?
-        elsif tag.reload.taggings.none?
-          tag.destroy
-        end
+      return unless ActsAsTaggableOn.remove_unused_tags
+
+      tag.reload if association(:tag).loaded?
+      if ActsAsTaggableOn.tags_counter
+        tag.destroy if tag.taggings_count.zero?
+      elsif tag.taggings.none?
+        # We already know there is no taggings, but the depended: :destroy will
+        # fire a query nonetheless, can we avoid it ?
+        tag.destroy
       end
     end
   end


### PR DESCRIPTION
Opening this pull request cause we noticed that this gem was making duplicate queries for the same resources on our app, and decided to dig in to find the root cause.

The main usecases were : 
- On delete, we notice that we the gem delete a Tagging, and then query the same Tag twice
- On `save!` with nothing changed, the gem queries existing Tags and Tags in current context, even tho nothing changed so the gem should not have to query anything
- On `save!` with changes (or not), the gem seems to query the same contexts multiple times, which is redundant

Here are improvements for the first and last usecase. The middle one seem more complex, and is left for a future improvement.

# Improvements 
For the delete improvement : 
We simply only reload the `tag` record if already loaded. Otherwise `tag.reload` would load it twice.

For the `save!` improvement : 
Since we initialize `custom_contexts` with `taggings.map(&:context).uniq`, but `tagging_contexts` uses both `self.class.tag_types.map(&:to_s)` and `custom_contexts`, we have duplicates contexts in `tagging_contexts` which results in the gem attempting to save each context twice.
Add a `uniq` to `tagging_contexts` to ensure that does not happen.