### PR TITLE
Provide a 'Changelog' link on rubygems.org/gems/acts-as-taggable-on

### DIFF
--- a/acts-as-taggable-on.gemspec
+++ b/acts-as-taggable-on.gemspec
@@ -29,4 +29,6 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'rspec'
   gem.add_development_dependency 'barrier'
   gem.add_development_dependency 'database_cleaner'
+
+  gem.metadata['changelog_uri'] = gem.homepage + '/blob/master/CHANGELOG.md'
 end


### PR DESCRIPTION
By providing a 'changelog_uri' in the metadata of the gemspec a 'Changelog' link will be shown on https://rubygems.org/gems/acts-as-taggable-on which makes it quick and easy for someone to check on the changes introduced with a new version.

Details of this functionality can be found on https://guides.rubygems.org/specification-reference/