### PR TITLE
feat!: support rails 8.0

### DIFF
--- a/.github/workflows/spec.yml
+++ b/.github/workflows/spec.yml
@@ -15,11 +15,10 @@ jobs:
         ruby:
           - 3.3
           - 3.2
-          - 3.1
         gemfile:
+          - gemfiles/activerecord_8.0.gemfile
           - gemfiles/activerecord_7.2.gemfile
           - gemfiles/activerecord_7.1.gemfile
-          - gemfiles/activerecord_7.0.gemfile
         db:
           - mysql
           - postgresql
@@ -27,7 +26,7 @@ jobs:
         include:
           - ruby: truffleruby-head
             db: postgresql
-            gemfile: gemfiles/activerecord_7.0.gemfile
+            gemfile: gemfiles/activerecord_8.0.gemfile
           - ruby: truffleruby-head
             db: postgresql
             gemfile: gemfiles/activerecord_7.1.gemfile

--- a/Appraisals
+++ b/Appraisals
@@ -1,12 +1,5 @@
 # frozen_string_literal: true
 
-appraise 'activerecord-7.0' do
-  gem 'activerecord', '~> 7.0.1'
-  gem 'pg'
-  gem 'sqlite3', '~> 1.4'
-  gem 'mysql2', '~> 0.5'
-end
-
 appraise 'activerecord-7.1' do
   gem 'activerecord', '~> 7.1.0'
   gem 'pg'
@@ -17,6 +10,14 @@ end
 appraise 'activerecord-7.2' do
   gem 'activerecord', '~> 7.2.0'
   gem 'pg'
-  gem 'sqlite3', '~> 1.4'
+  gem 'sqlite3', '~> 2.2'
+  gem 'mysql2', '~> 0.5'
+end
+
+appraise 'activerecord-8.0' do
+  gem 'activerecord', '~> 8.0.0.beta1'
+  gem 'railties', '~> 8.0.0.beta1'
+  gem 'pg'
+  gem 'sqlite3', '~> 2.2'
   gem 'mysql2', '~> 0.5'
 end

--- a/README.md
+++ b/README.md
@@ -571,6 +571,10 @@ Versions >= 8.x are compatible with Ruby 2.3.7+ and Rails 5 and 6.
 
 Versions >= 9.x are compatible with Ruby 2.5.0 and Rails 6 and 7.
 
+Versions >= 11.x are compatible with Ruby 3.1.0 and Rails 7.
+
+Versions >= 12.x are compatible with Ruby 3.2.0 and Rails 7.1 and 8.0.
+
 For an up-to-date roadmap, see https://github.com/mbleigh/acts-as-taggable-on/milestones
 
 ## Testing

--- a/acts-as-taggable-on.gemspec
+++ b/acts-as-taggable-on.gemspec
@@ -15,13 +15,13 @@ Gem::Specification.new do |gem|
   gem.files         = `git ls-files`.split($/)
   gem.test_files    = gem.files.grep(%r{^spec/})
   gem.require_paths = ['lib']
-  gem.required_ruby_version     = '>= 3.0.0'
+  gem.required_ruby_version     = '>= 3.2.0'
 
   if File.exist?('UPGRADING.md')
     gem.post_install_message = File.read('UPGRADING.md')
   end
 
-  gem.add_runtime_dependency 'activerecord', '>= 7.0', '< 8.0'
+  gem.add_runtime_dependency 'activerecord', '>= 7.1', '< 8.1'
   gem.add_runtime_dependency 'zeitwerk', '>= 2.4', '< 3.0'
 
   gem.add_development_dependency 'rspec-rails'
@@ -29,6 +29,4 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'rspec'
   gem.add_development_dependency 'barrier'
   gem.add_development_dependency 'database_cleaner'
-
-  gem.metadata['changelog_uri'] = gem.homepage + '/blob/master/CHANGELOG.md'
 end

--- a/gemfiles/activerecord_7.2.gemfile
+++ b/gemfiles/activerecord_7.2.gemfile
@@ -4,7 +4,7 @@ source "https://rubygems.org"
 
 gem "activerecord", "~> 7.2.0"
 gem "pg"
-gem "sqlite3", "~> 1.4"
+gem "sqlite3", "~> 2.1"
 gem "mysql2", "~> 0.5"
 
 group :local_development do

--- a/gemfiles/activerecord_8.0.gemfile
+++ b/gemfiles/activerecord_8.0.gemfile
@@ -2,9 +2,10 @@
 
 source "https://rubygems.org"
 
-gem "activerecord", "~> 7.0.1"
+gem "activerecord", "~> 8.0.0.beta1"
+gem "railties", "~> 8.0.0.beta1"
 gem "pg"
-gem "sqlite3", "~> 1.4"
+gem "sqlite3", "~> 2.1"
 gem "mysql2", "~> 0.5"
 
 group :local_development do

--- a/lib/acts-as-taggable-on/tag.rb
+++ b/lib/acts-as-taggable-on/tag.rb
@@ -33,7 +33,7 @@ module ActsAsTaggableOn
 
     def self.named_any(list)
       clause = list.map do |tag|
-        sanitize_sql_for_named_any(tag).force_encoding('BINARY')
+        sanitize_sql_for_named_any(tag)
       end.join(' OR ')
       where(clause)
     end


### PR DESCRIPTION
This PR upgrades `sqlite3` gem, and removes a `.force_encoding('BINARY')` that would otherwise cause an exception like `Encoding::UndefinedConversionError: "\xD0" from ASCII-8BIT to UTF-8` to be raised within the test suite. Removal of this `force_encoding` results in all tests passing.