### PR TITLE
Reduce packaged gem size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ As such, _Breaking Changes_ are major. _Features_ would map to either major or m
 
 * Features
   * [@tagliala Add back Ruby 3.1 compatibility](https://github.com/mbleigh/acts-as-taggable-on/pull/1082)
+  * Reduce packaged gem size
 
 ### [v11.0.0) / 2024-08-23](https://github.com/mbleigh/acts-as-taggable-on/compare/v10.0.0...v11.0.0)
 - Removed support for Ruby 2.7

--- a/acts-as-taggable-on.gemspec
+++ b/acts-as-taggable-on.gemspec
@@ -10,8 +10,7 @@ Gem::Specification.new do |gem|
   gem.homepage      = 'https://github.com/mbleigh/acts-as-taggable-on'
   gem.license       = 'MIT'
 
-  gem.files         = `git ls-files`.split($/)
-  gem.test_files    = gem.files.grep(%r{^spec/})
+  gem.files         = Dir['db/**/*', 'lib/**/*', 'LICENSE.md'].reject { |f| File.directory?(f) }
   gem.require_paths = ['lib']
   gem.required_ruby_version     = '>= 3.1.0'
 


### PR DESCRIPTION
This removes
- .github/
- .gitignore
- .rspec
- Appraisals
- CHANGELOG.md
- CONTRIBUTING.md
- Gemfile
- Guardfile
- README.md
- Rakefile
- acts-as-taggable-on.gemspec
- docker-compose.yml
- gemfiles/
- spec/