### PR TITLE
Remove redundant encoding

### DIFF
--- a/acts-as-taggable-on.gemspec
+++ b/acts-as-taggable-on.gemspec
@@ -1,5 +1,3 @@
-# coding: utf-8
-
 require_relative 'lib/acts-as-taggable-on/version'
 
 Gem::Specification.new do |gem|

--- a/spec/acts_as_taggable_on/acts_as_taggable_on_spec.rb
+++ b/spec/acts_as_taggable_on/acts_as_taggable_on_spec.rb
@@ -1,4 +1,3 @@
-# -*- encoding : utf-8 -*-
 require 'spec_helper'
 
 describe 'Acts As Taggable On' do

--- a/spec/acts_as_taggable_on/acts_as_tagger_spec.rb
+++ b/spec/acts_as_taggable_on/acts_as_tagger_spec.rb
@@ -1,4 +1,3 @@
-# -*- encoding : utf-8 -*-
 require 'spec_helper'
 
 describe 'acts_as_tagger' do

--- a/spec/acts_as_taggable_on/caching_spec.rb
+++ b/spec/acts_as_taggable_on/caching_spec.rb
@@ -1,4 +1,3 @@
-# -*- encoding : utf-8 -*-
 require 'spec_helper'
 
 describe 'Acts As Taggable On' do

--- a/spec/acts_as_taggable_on/default_parser_spec.rb
+++ b/spec/acts_as_taggable_on/default_parser_spec.rb
@@ -1,4 +1,3 @@
-# -*- encoding : utf-8 -*-
 require 'spec_helper'
 
 describe ActsAsTaggableOn::DefaultParser do

--- a/spec/acts_as_taggable_on/dirty_spec.rb
+++ b/spec/acts_as_taggable_on/dirty_spec.rb
@@ -1,4 +1,3 @@
-# -*- encoding : utf-8 -*-
 require 'spec_helper'
 
 describe 'Dirty behavior of taggable objects' do

--- a/spec/acts_as_taggable_on/generic_parser_spec.rb
+++ b/spec/acts_as_taggable_on/generic_parser_spec.rb
@@ -1,4 +1,3 @@
-# -*- encoding : utf-8 -*-
 require 'spec_helper'
 
 describe ActsAsTaggableOn::GenericParser do

--- a/spec/acts_as_taggable_on/related_spec.rb
+++ b/spec/acts_as_taggable_on/related_spec.rb
@@ -1,4 +1,3 @@
-# -*- encoding : utf-8 -*-
 require 'spec_helper'
 
 describe 'Acts As Taggable On' do

--- a/spec/acts_as_taggable_on/single_table_inheritance_spec.rb
+++ b/spec/acts_as_taggable_on/single_table_inheritance_spec.rb
@@ -1,4 +1,3 @@
-# -*- encoding : utf-8 -*-
 require 'spec_helper'
 
 describe 'Single Table Inheritance' do

--- a/spec/acts_as_taggable_on/tag_list_spec.rb
+++ b/spec/acts_as_taggable_on/tag_list_spec.rb
@@ -1,5 +1,3 @@
-# -*- encoding : utf-8 -*-
-
 require 'spec_helper'
 
 describe ActsAsTaggableOn::TagList do

--- a/spec/acts_as_taggable_on/tag_spec.rb
+++ b/spec/acts_as_taggable_on/tag_spec.rb
@@ -1,4 +1,3 @@
-# -*- encoding : utf-8 -*-
 require 'spec_helper'
 require 'db/migrate/2_add_missing_unique_indices.rb'
 

--- a/spec/acts_as_taggable_on/taggable_spec.rb
+++ b/spec/acts_as_taggable_on/taggable_spec.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 require 'spec_helper'
 
 describe 'Taggable To Preserve Order' do

--- a/spec/acts_as_taggable_on/tagger_spec.rb
+++ b/spec/acts_as_taggable_on/tagger_spec.rb
@@ -1,4 +1,3 @@
-# -*- encoding : utf-8 -*-
 require 'spec_helper'
 
 describe 'Tagger' do

--- a/spec/acts_as_taggable_on/tagging_spec.rb
+++ b/spec/acts_as_taggable_on/tagging_spec.rb
@@ -1,4 +1,3 @@
-# -*- encoding : utf-8 -*-
 require 'spec_helper'
 
 describe ActsAsTaggableOn::Tagging do

--- a/spec/acts_as_taggable_on/tags_helper_spec.rb
+++ b/spec/acts_as_taggable_on/tags_helper_spec.rb
@@ -1,4 +1,3 @@
-# -*- encoding : utf-8 -*-
 require 'spec_helper'
 
 describe ActsAsTaggableOn::TagsHelper do

--- a/spec/acts_as_taggable_on/utils_spec.rb
+++ b/spec/acts_as_taggable_on/utils_spec.rb
@@ -1,4 +1,3 @@
-# -*- encoding : utf-8 -*-
 require 'spec_helper'
 
 describe ActsAsTaggableOn::Utils do


### PR DESCRIPTION
This magic comment is not needed anymore because the default encoding of source code files assumed by Ruby 2 is utf-8, and the minimum required Ruby version is 3.1

Autofixed with:
```
rubocop -a --only Style/Encoding
```