### PR TITLE
Add back Ruby 3.1 compatibility

### DIFF
--- a/.github/workflows/spec.yml
+++ b/.github/workflows/spec.yml
@@ -15,6 +15,7 @@ jobs:
         ruby:
           - 3.3
           - 3.2
+          - 3.1
         gemfile:
           - gemfiles/activerecord_8.0.gemfile
           - gemfiles/activerecord_7.2.gemfile
@@ -33,6 +34,9 @@ jobs:
           - ruby: truffleruby-head
             db: postgresql
             gemfile: gemfiles/activerecord_7.2.gemfile
+        exclude:
+          - ruby: 3.1
+            gemfile: gemfiles/activerecord_8.0.gemfile
 
     services:
       postgres:

--- a/Appraisals
+++ b/Appraisals
@@ -15,8 +15,7 @@ appraise 'activerecord-7.2' do
 end
 
 appraise 'activerecord-8.0' do
-  gem 'activerecord', '~> 8.0.0.beta1'
-  gem 'railties', '~> 8.0.0.beta1'
+  gem 'activerecord', '~> 8.0.0'
   gem 'pg'
   gem 'sqlite3', '~> 2.2'
   gem 'mysql2', '~> 0.5'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ Each change should fall into categories that would affect whether the release is
 
 As such, _Breaking Changes_ are major. _Features_ would map to either major or minor. _Fixes_, _Performance_, and _Misc_ are either minor or patch, the difference being kind of fuzzy for the purposes of history. Adding _Documentation_ (including tests) would be patch level.
 
+### unreleased
+
+* Features
+  * [@tagliala Add back Ruby 3.1 compatibility](https://github.com/mbleigh/acts-as-taggable-on/pull/1082)
+
 ### [v11.0.0) / 2024-08-23](https://github.com/mbleigh/acts-as-taggable-on/compare/v10.0.0...v11.0.0)
 - Removed support for Ruby 2.7
 - Removed support for Rails 6.1

--- a/acts-as-taggable-on.gemspec
+++ b/acts-as-taggable-on.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |gem|
   gem.files         = `git ls-files`.split($/)
   gem.test_files    = gem.files.grep(%r{^spec/})
   gem.require_paths = ['lib']
-  gem.required_ruby_version     = '>= 3.2.0'
+  gem.required_ruby_version     = '>= 3.1.0'
 
   if File.exist?('UPGRADING.md')
     gem.post_install_message = File.read('UPGRADING.md')

--- a/gemfiles/activerecord_7.2.gemfile
+++ b/gemfiles/activerecord_7.2.gemfile
@@ -4,7 +4,7 @@ source "https://rubygems.org"
 
 gem "activerecord", "~> 7.2.0"
 gem "pg"
-gem "sqlite3", "~> 2.1"
+gem "sqlite3", "~> 2.2"
 gem "mysql2", "~> 0.5"
 
 group :local_development do

--- a/gemfiles/activerecord_8.0.gemfile
+++ b/gemfiles/activerecord_8.0.gemfile
@@ -2,10 +2,9 @@
 
 source "https://rubygems.org"
 
-gem "activerecord", "~> 8.0.0.beta1"
-gem "railties", "~> 8.0.0.beta1"
+gem "activerecord", "~> 8.0.0"
 gem "pg"
-gem "sqlite3", "~> 2.1"
+gem "sqlite3", "~> 2.2"
 gem "mysql2", "~> 0.5"
 
 group :local_development do


### PR DESCRIPTION
Close #1138

---

Failures with TruffleRuby do not depend by this PR

Ref: https://github.com/tagliala/acts-as-taggable-on/pull/2