### PR TITLE
Provide a 'Changelog' link on rubygems.org/gems/acts-as-taggable-on

### DIFF
--- a/acts-as-taggable-on.gemspec
+++ b/acts-as-taggable-on.gemspec
@@ -14,7 +14,8 @@ Gem::Specification.new do |gem|
   gem.require_paths = ['lib']
   gem.required_ruby_version     = '>= 3.1.0'
 
-  gem.metadata = { 'rubygems_mfa_required' => 'true' }
+  gem.metadata = { 'changelog_uri' => gem.homepage + '/blob/master/CHANGELOG.md',
+                   'rubygems_mfa_required' => 'true' }
 
   if File.exist?('UPGRADING.md')
     gem.post_install_message = File.read('UPGRADING.md')


### PR DESCRIPTION
By providing a 'changelog_uri' in the metadata of the gemspec a 'Changelog' link will be shown on https://rubygems.org/gems/acts-as-taggable-on which makes it quick and easy for someone to check on the changes introduced with a new version.

Details of this functionality can be found on https://guides.rubygems.org/specification-reference/