### PR TITLE
Fix mismatched indentations warning message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ As such, _Breaking Changes_ are major. _Features_ would map to either major or m
 * Features
   * [@tagliala Add back Ruby 3.1 compatibility](https://github.com/mbleigh/acts-as-taggable-on/pull/1082)
   * Reduce packaged gem size
+* Fixes
+  * [@iainbeeston Fix mismatched indentations warning message](https://github.com/mbleigh/acts-as-taggable-on/pull/1150)
 
 ### [v12.0.0) / 2024-11-09](https://github.com/mbleigh/acts-as-taggable-on/compare/v11.0.0...v12.0.0)
 

--- a/lib/acts-as-taggable-on.rb
+++ b/lib/acts-as-taggable-on.rb
@@ -10,7 +10,7 @@ loader.setup
 begin
   require 'rails/engine'
   require 'acts-as-taggable-on/engine'
-  rescue LoadError
+rescue LoadError
 end
 
 require 'digest/sha1'


### PR DESCRIPTION
If you run ruby with warnings enabled there is a warning message from `acts-as-taggable-on.rb` because the `begin` and `rescue` on line 10 aren't aligned:

    lib/acts-as-taggable-on.rb:13: warning: mismatched indentations at 'rescue' with 'begin' at 10

I've aligned them, which fixes the warning message.