### PR TITLE
CI: add Ruby 3.4 to build matrix

### DIFF
--- a/.github/workflows/spec.yml
+++ b/.github/workflows/spec.yml
@@ -13,6 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
+          - 3.4
           - 3.3
           - 3.2
           - 3.1


### PR DESCRIPTION
This PR updates the CI matrix to the latest generally available Ruby version.
