### PR TITLE
Remove deprecated/obsolete Unicode handling code

### DIFF
--- a/lib/acts-as-taggable-on/tag.rb
+++ b/lib/acts-as-taggable-on/tag.rb
@@ -25,9 +25,9 @@ module ActsAsTaggableOn
 
     def self.named(name)
       if ActsAsTaggableOn.strict_case_match
-        where(["name = #{binary}?", as_8bit_ascii(name)])
+        where(["name = ?", name])
       else
-        where(['LOWER(name) = LOWER(?)', as_8bit_ascii(unicode_downcase(name))])
+        where(['LOWER(name) = LOWER(?)', name.to_s.downcase])
       end
     end
 
@@ -118,27 +118,15 @@ module ActsAsTaggableOn
         if ActsAsTaggableOn.strict_case_match
           str
         else
-          unicode_downcase(str.to_s)
+          str.to_s.downcase
         end
-      end
-
-      def binary
-        ActsAsTaggableOn::Utils.using_mysql? ? 'BINARY ' : nil
-      end
-
-      def as_8bit_ascii(string)
-        string.to_s.mb_chars
-      end
-
-      def unicode_downcase(string)
-        as_8bit_ascii(string).downcase
       end
 
       def sanitize_sql_for_named_any(tag)
         if ActsAsTaggableOn.strict_case_match
-          sanitize_sql(["name = #{binary}?", as_8bit_ascii(tag)])
+          sanitize_sql(["name = ?", tag])
         else
-          sanitize_sql(['LOWER(name) = LOWER(?)', as_8bit_ascii(unicode_downcase(tag))])
+          sanitize_sql(['LOWER(name) = LOWER(?)', tag.to_s.downcase])
         end
       end
     end

--- a/lib/acts-as-taggable-on/tag_list.rb
+++ b/lib/acts-as-taggable-on/tag_list.rb
@@ -82,7 +82,7 @@ module ActsAsTaggableOn
       reject!(&:blank?)
       map!(&:to_s)
       map!(&:strip)
-      map! { |tag| tag.mb_chars.downcase.to_s } if ActsAsTaggableOn.force_lowercase
+      map! { |tag| tag.downcase.to_s } if ActsAsTaggableOn.force_lowercase
       map!(&:parameterize) if ActsAsTaggableOn.force_parameterize
 
       ActsAsTaggableOn.strict_case_match ? uniq! : uniq!(&:downcase)


### PR DESCRIPTION
Not needed in current supported versions of Ruby.

thank you!