### PR TITLE
optimize all-tags-query using a query instead of a join per tag

### DIFF
--- a/lib/acts-as-taggable-on/taggable/tagged_with_query/all_tags_query.rb
+++ b/lib/acts-as-taggable-on/taggable/tagged_with_query/all_tags_query.rb
@@ -5,94 +5,81 @@ module ActsAsTaggableOn
     module TaggedWithQuery
       class AllTagsQuery < QueryBase
         def build
-          taggable_model.joins(each_tag_in_list)
-                        .group(by_taggable)
-                        .having(tags_that_matches_count)
-                        .order(order_conditions)
-                        .readonly(false)
+          scope = taggable_model.where(
+            taggable_arel_table[taggable_model.primary_key].in(
+              taggables_with_all_tags
+            )
+          )
+
+          if options[:match_all].present?
+            taggable_model.find_by_sql(tag_arel_table.project(Arel.star.count).where(tags_match_type).to_sql)
+
+            scope = scope.where(
+              taggable_arel_table[taggable_model.primary_key].in(
+                taggables_with_exact_tag_count
+              )
+            )
+          end
+
+          scope.order(order_conditions).readonly(false)
         end
 
         private
 
-        def each_tag_in_list
-          arel_join = taggable_arel_table
-
-          tag_list.each do |tag|
-            tagging_alias = tagging_arel_table.alias(tagging_alias(tag))
-            arel_join = arel_join
-                        .join(tagging_alias)
-                        .on(on_conditions(tag, tagging_alias))
-          end
-
-          if options[:match_all].present?
-            arel_join = arel_join
-                        .join(tagging_arel_table, Arel::Nodes::OuterJoin)
-                        .on(
-                          match_all_on_conditions
-                        )
-          end
-
-          arel_join.join_sources
+        def taggables_with_all_tags
+          tagging_arel_table
+            .project(tagging_arel_table[:taggable_id])
+            .where(tagging_conditions)
+            .group(tagging_arel_table[:taggable_id])
+            .having(tagging_arel_table[:tag_id].count(true).eq(tag_list.size))
         end
 
-        def on_conditions(tag, tagging_alias)
-          on_condition = tagging_alias[:taggable_id].eq(taggable_arel_table[taggable_model.primary_key])
-                                                    .and(tagging_alias[:taggable_type].eq(taggable_model.base_class.name))
-                                                    .and(
-                                                      tagging_alias[:tag_id].in(
-                                                        tag_arel_table.project(tag_arel_table[:id]).where(tag_match_type(tag))
-                                                      )
-                                                    )
+        def tagging_conditions
+          condition = tagging_arel_table[:taggable_type].eq(taggable_model.base_class.name)
+                                                        .and(
+                                                          tagging_arel_table[:tag_id].in(
+                                                            tag_arel_table.project(tag_arel_table[:id]).where(tags_match_type)
+                                                          )
+                                                        )
 
           if options[:start_at].present?
-            on_condition = on_condition.and(tagging_alias[:created_at].gteq(options[:start_at]))
+            condition = condition.and(tagging_arel_table[:created_at].gteq(options[:start_at]))
           end
 
-          if options[:end_at].present?
-            on_condition = on_condition.and(tagging_alias[:created_at].lteq(options[:end_at]))
-          end
+          condition = condition.and(tagging_arel_table[:created_at].lteq(options[:end_at])) if options[:end_at].present?
 
-          on_condition = on_condition.and(tagging_alias[:context].eq(options[:on])) if options[:on].present?
+          condition = condition.and(tagging_arel_table[:context].eq(options[:on])) if options[:on].present?
 
           if (owner = options[:owned_by]).present?
-            on_condition = on_condition.and(tagging_alias[:tagger_id].eq(owner.id))
-                                       .and(tagging_alias[:tagger_type].eq(owner.class.base_class.to_s))
+            condition = condition.and(tagging_arel_table[:tagger_id].eq(owner.id))
+                                 .and(tagging_arel_table[:tagger_type].eq(owner.class.base_class.to_s))
           end
 
-          on_condition
+          condition
         end
 
-        def match_all_on_conditions
-          on_condition = tagging_arel_table[:taggable_id].eq(taggable_arel_table[taggable_model.primary_key])
-                                                         .and(tagging_arel_table[:taggable_type].eq(taggable_model.base_class.name))
+        def taggables_with_exact_tag_count
+          all_condition = tagging_arel_table[:taggable_type].eq(taggable_model.base_class.name)
 
           if options[:start_at].present?
-            on_condition = on_condition.and(tagging_arel_table[:created_at].gteq(options[:start_at]))
+            all_condition = all_condition.and(tagging_arel_table[:created_at].gteq(options[:start_at]))
           end
 
           if options[:end_at].present?
-            on_condition = on_condition.and(tagging_arel_table[:created_at].lteq(options[:end_at]))
+            all_condition = all_condition.and(tagging_arel_table[:created_at].lteq(options[:end_at]))
           end
 
-          on_condition = on_condition.and(tagging_arel_table[:context].eq(options[:on])) if options[:on].present?
+          all_condition = all_condition.and(tagging_arel_table[:context].eq(options[:on])) if options[:on].present?
 
-          on_condition
-        end
-
-        def by_taggable
-          return [] if options[:match_all].blank?
-
-          taggable_arel_table[taggable_model.primary_key]
-        end
-
-        def tags_that_matches_count
-          return [] if options[:match_all].blank?
-
-          taggable_model.find_by_sql(tag_arel_table.project(Arel.star.count).where(tags_match_type).to_sql)
-
-          tagging_arel_table[:taggable_id].count.eq(
-            tag_arel_table.project(Arel.star.count).where(tags_match_type)
-          )
+          tagging_arel_table
+            .project(tagging_arel_table[:taggable_id])
+            .where(all_condition)
+            .group(tagging_arel_table[:taggable_id])
+            .having(
+              tagging_arel_table[:id].count.eq(
+                tag_arel_table.project(Arel.star.count).where(tags_match_type)
+              )
+            )
         end
 
         def order_conditions
@@ -103,11 +90,6 @@ module ActsAsTaggableOn
 
           order_by << options[:order] if options[:order].present?
           order_by.join(', ')
-        end
-
-        def tagging_alias(tag)
-          alias_base_name = taggable_model.base_class.name.downcase
-          adjust_taggings_alias("#{alias_base_name[0..11]}_taggings_#{ActsAsTaggableOn::Utils.sha_prefix(tag)}")
         end
       end
     end

--- a/spec/acts_as_taggable_on/taggable_spec.rb
+++ b/spec/acts_as_taggable_on/taggable_spec.rb
@@ -238,7 +238,7 @@ RSpec.describe 'Taggable' do
     @taggable.skill_list = 'ruby, rails, css'
     @taggable.save
 
-    expect(TaggableModel.tagged_with('ruby').to_sql).to_not match /DISTINCT/
+    expect(TaggableModel.tagged_with('ruby').to_sql).to_not match /SELECT DISTINCT/
   end
 
   it "should be able to find a tag using dates" do
@@ -268,7 +268,7 @@ RSpec.describe 'Taggable' do
     expect(TaggableModel.tagged_with('bob', on: :tags).first).to eq(@taggable)
     expect(TaggableModel.tagged_with('julia', on: :skills).size).to eq(1)
     expect(TaggableModel.tagged_with('julia', on: :tags).size).to eq(1)
-    expect(TaggableModel.tagged_with('julia', on: nil).size).to eq(2)
+    expect(TaggableModel.tagged_with('julia', on: nil).size).to eq(1)
   end
 
   it 'should not care about case' do
@@ -523,6 +523,12 @@ RSpec.describe 'Taggable' do
     TaggableModel.create(name: 'Steve', tag_list: 'fitter, happier', skill_list: 'ruby, rails, css')
 
     expect(TaggableModel.tagged_with('css', on: :skills, match_all: true).to_a).to eq([frank])
+  end
+
+  it 'should not generate joins for tagged_with queries' do
+    TaggableModel.create(name: 'Bob', tag_list: 'ruby, rails, css')
+    expect(TaggableModel.tagged_with('ruby').to_sql).not_to match(/JOIN/)
+    expect(TaggableModel.tagged_with('ruby, rails, css').to_sql).not_to match(/JOIN/)
   end
 
   it 'should be able to find tagged with some excluded tags' do


### PR DESCRIPTION
**Problem**

ActsAsTaggableOn’s AllTagsQuery generates one INNER JOIN per tag when calling tagged_with.

Passing N tags results in N joins on the taggings table, each with its own alias and conditions. Query complexity/memory usage therefore grows linearly with tag count.

With large tag lists, this leads to:
	•	High memory usage
	•	Slow query planning and execution
	•	Rapidly expanding SQL

If the join count exceeds database limits (e.g., planner or memory thresholds), queries can fail or even destabilize the database under load. (we have experienced this at least twice)

before:
```
SELECT "taggable_models".*
FROM "taggable_models"
INNER JOIN "taggings" "taggablemode_taggings_18e40e1"
  ON "taggablemode_taggings_18e40e1"."taggable_id" = "taggable_models"."id"
  AND "taggablemode_taggings_18e40e1"."taggable_type" = 'TaggableModel'
  AND "taggablemode_taggings_18e40e1"."tag_id" IN (
    SELECT "tags"."id" FROM "tags" WHERE LOWER("tags"."name") LIKE 'ruby' ESCAPE '!'
  )
INNER JOIN "taggings" "taggablemode_taggings_79fdb82"
  ON "taggablemode_taggings_79fdb82"."taggable_id" = "taggable_models"."id"
  AND "taggablemode_taggings_79fdb82"."taggable_type" = 'TaggableModel'
  AND "taggablemode_taggings_79fdb82"."tag_id" IN (
    SELECT "tags"."id" FROM "tags" WHERE LOWER("tags"."name") LIKE 'rails' ESCAPE '!'
  )
INNER JOIN "taggings" "taggablemode_taggings_2f84417"
  ON "taggablemode_taggings_2f84417"."taggable_id" = "taggable_models"."id"
  AND "taggablemode_taggings_2f84417"."taggable_type" = 'TaggableModel'
  AND "taggablemode_taggings_2f84417"."tag_id" IN (
    SELECT "tags"."id" FROM "tags" WHERE LOWER("tags"."name") LIKE 'css' ESCAPE '!'
  )
```
⸻

**Fix**

Replaced the N-join loop with a single-join/subquery approach:
	•	Single tag: one aliased INNER JOIN (unchanged behavior, no GROUP BY)
	•	Multiple tags: single WHERE IN subquery with
GROUP BY taggable_id + HAVING COUNT(DISTINCT tag_id) = N
	•	match_all: adds a second subquery to enforce exact tag count

All existing filters (context, ownership, date range, wildcards) and chaining support are preserved.

This ensures stable query complexity and consistent performance regardless of tag count.

after:
```
SELECT "taggable_models".*
FROM "taggable_models"
WHERE "taggable_models"."id" IN (
  SELECT "taggings"."taggable_id"
  FROM "taggings"
  WHERE "taggings"."taggable_type" = 'TaggableModel'
    AND "taggings"."tag_id" IN (
      SELECT "tags"."id" FROM "tags"
      WHERE (LOWER("tags"."name") LIKE 'ruby' ESCAPE '!'
        OR LOWER("tags"."name") LIKE 'rails' ESCAPE '!'
        OR LOWER("tags"."name") LIKE 'css' ESCAPE '!')
    )
  GROUP BY "taggings"."taggable_id"
  HAVING COUNT(DISTINCT "taggings"."tag_id") = 3
)
```

**Potential Improvement (included)**


The single-tag path uses a JOIN which returns one row per matching tagging record, preserving the existing behavior. For example, the test at [line 271](https://github.com/mbleigh/acts-as-taggable-on/blob/master/spec/acts_as_taggable_on/taggable_spec.rb#L271) shows that tagged_with('julia', on: nil) returns 2 results when Julia is tagged once as a skill and once as a tag on the same model. The multi-tag subquery path, by contrast, deduplicates by taggable_id and returns each record once.

This could be unified to always return one record per taggable by using the subquery path for all cases, removing the single-tag/multi-tag branch. Happy to make that change if reviewers prefer the deduplicated behavior.


**Open question**

From my experience using the GEM (we use it heavily, we have 300M+ tags in our database)

I’m confident this approach significantly improves memory usage and prevents the join explosion issue we’ve seen before. However, since we’re now relying on a GROUP BY + HAVING COUNT(DISTINCT tag_id) subquery, I want to make sure we’re not introducing any unintended planning or execution overhead.

Do you think we should add or adjust indexes (e.g., on taggings) to minimize any potential performance impact?