### PR TITLE
Performance improvements

### DIFF
--- a/lib/acts-as-taggable-on/taggable/core.rb
+++ b/lib/acts-as-taggable-on/taggable/core.rb
@@ -212,7 +212,7 @@ module ActsAsTaggableOn
       end
 
       def tagging_contexts
-        self.class.tag_types.map(&:to_s) + custom_contexts
+        (self.class.tag_types.map(&:to_s) + custom_contexts).uniq
       end
 
       def taggable_tenant

--- a/lib/acts-as-taggable-on/taggable/ownership.rb
+++ b/lib/acts-as-taggable-on/taggable/ownership.rb
@@ -88,6 +88,7 @@ module ActsAsTaggableOn
         super(*args)
       end
 
+      # This looks duplicated from taggable/core.rb
       def save_owned_tags
         tagging_contexts.each do |context|
           cached_owned_tag_list_on(context).each do |owner, tag_list|

--- a/lib/acts-as-taggable-on/tagging.rb
+++ b/lib/acts-as-taggable-on/tagging.rb
@@ -28,12 +28,15 @@ module ActsAsTaggableOn
     private
 
     def remove_unused_tags
-      if ActsAsTaggableOn.remove_unused_tags
-        if ActsAsTaggableOn.tags_counter
-          tag.destroy if tag.reload.taggings_count.zero?
-        elsif tag.reload.taggings.none?
-          tag.destroy
-        end
+      return unless ActsAsTaggableOn.remove_unused_tags
+
+      tag.reload if association(:tag).loaded?
+      if ActsAsTaggableOn.tags_counter
+        tag.destroy if tag.taggings_count.zero?
+      elsif tag.taggings.none?
+        # We already know there is no taggings, but the depended: :destroy will
+        # fire a query nonetheless, can we avoid it ?
+        tag.destroy
       end
     end
   end

--- a/spec/acts_as_taggable_on/tagging_spec.rb
+++ b/spec/acts_as_taggable_on/tagging_spec.rb
@@ -64,6 +64,33 @@ RSpec.describe ActsAsTaggableOn::Tagging do
     ActsAsTaggableOn.tags_counter = tags_counter_previous_setting
   end
 
+  context 'when removing unused tags' do
+    before do
+      ActsAsTaggableOn.remove_unused_tags = true
+    end
+
+    it 'should call reload on tag if it was loaded' do
+      @taggable = TaggableModel.create(name: 'Bob Jones')
+      @taggable.tag_list.add('aaa')
+      @taggable.save
+      tagging = @taggable.taggings.first
+      tagging.tag # load the tag
+
+      expect(tagging.tag).to receive(:reload).once
+      tagging.destroy
+    end
+
+    it 'should not call reload on tag if it was not loaded' do
+      @taggable = TaggableModel.create(name: 'Bob Jones')
+      @taggable.tag_list.add('aaa')
+      @taggable.save
+      tagging = @taggable.taggings.first
+
+      expect_any_instance_of(ActsAsTaggableOn::Tag).to_not receive(:reload)
+      tagging.destroy
+    end
+  end
+
   describe 'context scopes' do
     before do
       @tagging_2 = ActsAsTaggableOn::Tagging.new

--- a/spec/acts_as_taggable_on/tagging_spec.rb
+++ b/spec/acts_as_taggable_on/tagging_spec.rb
@@ -65,8 +65,12 @@ RSpec.describe ActsAsTaggableOn::Tagging do
   end
 
   context 'when removing unused tags' do
-    before do
+    around(:example) do |example|
+      original_value = ActsAsTaggableOn.remove_unused_tags
       ActsAsTaggableOn.remove_unused_tags = true
+      example.run
+    ensure
+      ActsAsTaggableOn.remove_unused_tags = original_value
     end
 
     it 'should call reload on tag if it was loaded' do


### PR DESCRIPTION
Re-opening https://github.com/mbleigh/acts-as-taggable-on/pull/1121 

For some reason, I did not receive any notifications about the comments / pings, sorry about that

Original Description: 

----

Opening this pull request cause we noticed that this gem was making duplicate queries for the same resources on our app, and decided to dig in to find the root cause.

The main usecases were : 
- On delete, we notice that we the gem delete a Tagging, and then query the same Tag twice
- On `save!` with nothing changed, the gem queries existing Tags and Tags in current context, even tho nothing changed so the gem should not have to query anything
- On `save!` with changes (or not), the gem seems to query the same contexts multiple times, which is redundant

Here are improvements for the first and last usecase. The middle one seem more complex, and is left for a future improvement.

# Improvements 
For the delete improvement : 
We simply only reload the `tag` record if already loaded. Otherwise `tag.reload` would load it twice.

For the `save!` improvement : 
Since we initialize `custom_contexts` with `taggings.map(&:context).uniq`, but `tagging_contexts` uses both `self.class.tag_types.map(&:to_s)` and `custom_contexts`, we have duplicates contexts in `tagging_contexts` which results in the gem attempting to save each context twice.
Add a `uniq` to `tagging_contexts` to ensure that does not happen.