### PR TITLE
Use lease_connection to avoid ActiveRecord::Base.connection deprecation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ As such, _Breaking Changes_ are major. _Features_ would map to either major or m
 
 ### unreleased
 
+* Fixes
+  * Use `lease_connection` in `ActsAsTaggableOn::Utils.connection` to avoid the Rails 7.2 `ActiveRecord::Base.connection` deprecation warning, falling back to `connection` on ActiveRecord < 7.2
+
 ### [v13.0.0) / 2025-10-31](https://github.com/mbleigh/acts-as-taggable-on/compare/v12.0.0...v13.0.0)
 
 * Features

--- a/lib/acts-as-taggable-on/utils.rb
+++ b/lib/acts-as-taggable-on/utils.rb
@@ -6,8 +6,16 @@ module ActsAsTaggableOn
   module Utils
     class << self
       # Use ActsAsTaggableOn::Tag connection
+      #
+      # Rails 7.2 deprecated the model-level `.connection` in favour of
+      # `lease_connection` (rails/rails#51230). Prefer it when available and
+      # fall back to `connection` for ActiveRecord < 7.2.
       def connection
-        ActsAsTaggableOn::Tag.connection
+        if ActsAsTaggableOn::Tag.respond_to?(:lease_connection)
+          ActsAsTaggableOn::Tag.lease_connection
+        else
+          ActsAsTaggableOn::Tag.connection
+        end
       end
 
       def using_postgresql?

--- a/spec/acts_as_taggable_on/utils_spec.rb
+++ b/spec/acts_as_taggable_on/utils_spec.rb
@@ -13,6 +13,25 @@ RSpec.describe ActsAsTaggableOn::Utils do
     end
   end
 
+  describe '#connection' do
+    it 'uses lease_connection when the model responds to it' do
+      leased = ActsAsTaggableOn::Tag.connection
+      allow(ActsAsTaggableOn::Tag).to receive(:respond_to?).with(:lease_connection).and_return(true)
+      allow(ActsAsTaggableOn::Tag).to receive(:lease_connection).and_return(leased)
+
+      expect(ActsAsTaggableOn::Utils.connection).to eq(leased)
+      expect(ActsAsTaggableOn::Tag).to have_received(:lease_connection)
+    end
+
+    it 'falls back to connection when lease_connection is unavailable' do
+      legacy = ActsAsTaggableOn::Tag.connection
+      allow(ActsAsTaggableOn::Tag).to receive(:respond_to?).with(:lease_connection).and_return(false)
+      allow(ActsAsTaggableOn::Tag).to receive(:connection).and_return(legacy)
+
+      expect(ActsAsTaggableOn::Utils.connection).to eq(legacy)
+    end
+  end
+
   describe '#sha_prefix' do
     it 'should return a consistent prefix for a given word' do
       expect(ActsAsTaggableOn::Utils.sha_prefix('kittens')).to eq(ActsAsTaggableOn::Utils.sha_prefix('kittens'))


### PR DESCRIPTION
Rails 7.2 soft-deprecated the model-level `ActiveRecord::Base.connection` in favour of `lease_connection` ([rails/rails#51230](https://github.com/rails/rails/pull/51230)). `ActsAsTaggableOn::Utils.connection` calls `ActsAsTaggableOn::Tag.connection`, so every tag operation that goes through `Utils` (e.g. `using_postgresql?`, `like_operator`) emits:

```
DEPRECATION WARNING: Called deprecated `ActiveRecord::Base.connection` method.
Either use `with_connection` or `lease_connection`.
 (called from ActsAsTaggableOn::Utils.connection at .../acts-as-taggable-on/utils.rb:10)
```

This switches `Utils.connection` to `lease_connection` when the model responds to it, falling back to `connection` for ActiveRecord < 7.2 (the gem still supports `>= 7.1`). `lease_connection` returns the same leased-per-thread connection that `connection` did, so behaviour is unchanged.

Added specs covering both the `lease_connection` path and the legacy fallback.